### PR TITLE
Fix graph template and validator bugs found during live runs

### DIFF
--- a/config/examples/brownfield.yaml
+++ b/config/examples/brownfield.yaml
@@ -357,6 +357,7 @@ Orchestration:
         RULES:
         - Never call HANDOFF TO REVIEWER before writing .fuseraft/test-report.json.
         - Never fabricate shell output.
+        - A PASS result with an empty or missing command field is treated as fabricated and will block handoff.
       Model:
         ModelId: reasoning
         MaxTokens: 16384

--- a/config/examples/dev-team-structured.yaml
+++ b/config/examples/dev-team-structured.yaml
@@ -203,6 +203,7 @@ Orchestration:
         RULES:
         - Never call HANDOFF TO REVIEWER before writing .fuseraft/test-report.json.
         - Never fabricate shell output.
+        - A PASS result with an empty or missing command field is treated as fabricated and will block handoff.
       Model:
         ModelId: reasoning
         MaxTokens: 16384

--- a/config/examples/open-webui.yaml
+++ b/config/examples/open-webui.yaml
@@ -208,6 +208,7 @@ Orchestration:
         RULES:
         - NEVER call HANDOFF TO REVIEWER unless every criterion has real shell_run output showing PASS.
         - NEVER call HANDOFF TO REVIEWER before writing .fuseraft/test-report.json to disk.
+        - A PASS result with an empty or missing command field is treated as fabricated and will block handoff.
       Model:
         ModelId: owui-default
         MaxTokens: 16384

--- a/config/examples/orchestration.yaml
+++ b/config/examples/orchestration.yaml
@@ -174,6 +174,7 @@ Orchestration:
                ],
                "fake_test_files": []
              }
+           The command field is required for every PASS — an empty command is rejected as fabricated.
         6. HAND OFF:
            - All criteria PASS → call handoff(route_keyword: "HANDOFF TO REVIEWER").
            - Any criterion FAIL → call handoff(route_keyword: "BUGS FOUND").

--- a/src/Cli/Commands/InitTemplates.cs
+++ b/src/Cli/Commands/InitTemplates.cs
@@ -1123,6 +1123,18 @@ internal static class InitTemplates
             {AgentFileOptions}
             """;
 
+        var approved = $"""
+            Name: Approved
+            Description: Terminal confirmation node — emits a one-line completion summary.
+            Instructions: |
+              All acceptance criteria have already been verified and approved.
+              Write exactly one sentence confirming the task is complete. Nothing else.
+            Model:
+              ModelId: {model}{EpAgent(endpoint)}
+            FunctionChoice: none
+            {AgentFileOptions}
+            """;
+
         var mainConfig = $"""
             Orchestration:
               Name: Graph Pipeline
@@ -1149,6 +1161,7 @@ internal static class InitTemplates
                 - AgentFile: agents/developer.yaml
                 - AgentFile: agents/tester.yaml
                 - AgentFile: agents/reviewer.yaml
+                - AgentFile: agents/approved.yaml
 
               Selection:
                 Type: graph
@@ -1168,7 +1181,7 @@ internal static class InitTemplates
                     - Id: reviewer
                       Agent: Reviewer             # routes on keyword — NOT terminal
                     - Id: approved                # terminal node — session ends after this run
-                      Agent: Reviewer             # same agent, terminal confirmation
+                      Agent: Approved
                       Terminal: true
 
                   # Edges define control flow — first matching edge fires each turn.
@@ -1256,6 +1269,7 @@ internal static class InitTemplates
             ("agents/developer.yaml", developer),
             ("agents/tester.yaml",    tester),
             ("agents/reviewer.yaml",  reviewer),
+            ("agents/approved.yaml",  approved),
         ]);
     }
 
@@ -1383,6 +1397,18 @@ internal static class InitTemplates
             {AgentFileOptions}
             """;
 
+        var approved = $"""
+            Name: Approved
+            Description: Terminal confirmation node — emits a one-line completion summary.
+            Instructions: |
+              All acceptance criteria have already been verified and approved.
+              Write exactly one sentence confirming the task is complete. Nothing else.
+            Model:
+              ModelId: {model}{EpAgent(endpoint)}
+            FunctionChoice: none
+            {AgentFileOptions}
+            """;
+
         var mainConfig = $"""
             Orchestration:
               Name: Brownfield Graph Pipeline
@@ -1420,6 +1446,7 @@ internal static class InitTemplates
                 - AgentFile: agents/planner.yaml
                 - AgentFile: agents/developer.yaml
                 - AgentFile: agents/reviewer.yaml
+                - AgentFile: agents/approved.yaml
 
               Selection:
                 Type: graph
@@ -1437,7 +1464,7 @@ internal static class InitTemplates
                     - Id: reviewer
                       Agent: Reviewer             # routes on keyword — NOT terminal
                     - Id: approved                # terminal node — session ends after this run
-                      Agent: Reviewer             # same agent, terminal confirmation
+                      Agent: Approved
                       Terminal: true
 
                   # ── Key pattern: Reviewer routes to TWO different back-edge targets ──────
@@ -1537,6 +1564,7 @@ internal static class InitTemplates
             ("agents/planner.yaml",       planner),
             ("agents/developer.yaml",     developer),
             ("agents/reviewer.yaml",      reviewer),
+            ("agents/approved.yaml",      approved),
         ]);
     }
 

--- a/src/Cli/Commands/InitTemplates.cs
+++ b/src/Cli/Commands/InitTemplates.cs
@@ -197,7 +197,9 @@ internal static class InitTemplates
               2. Write tests and run them with shell_run.
               3. Write results to {FuseraftPaths.LocalTestReport} with fields:
                    passed — true or false
-                   results — array of objects, each with name, status (PASS or FAIL), and exit_code
+                   results — array of objects, each with name, status (PASS or FAIL), exit_code, and command
+                   command — the exact shell command you ran to verify this result (required for every PASS)
+              A PASS result with an empty or missing command field is treated as fabricated and will block handoff.
               If all pass, call handoff(route_keyword: "HANDOFF TO REVIEWER").
               If any fail, call handoff(route_keyword: "BUGS FOUND").
             Model:
@@ -1081,7 +1083,9 @@ internal static class InitTemplates
               2. Write tests and run them with shell_run.
               3. Write results to {FuseraftPaths.LocalTestReport} with fields:
                    passed — true or false
-                   results — array of objects, each with name, status (PASS or FAIL), and exit_code
+                   results — array of objects, each with name, status (PASS or FAIL), exit_code, and command
+                   command — the exact shell command you ran to verify this result (required for every PASS)
+              A PASS result with an empty or missing command field is treated as fabricated and will block handoff.
               If all tests pass, call handoff(route_keyword: "HANDOFF TO REVIEWER").
               If any tests fail, call handoff(route_keyword: "BUGS FOUND").
             Model:

--- a/src/Cli/Commands/InitTemplates.cs
+++ b/src/Cli/Commands/InitTemplates.cs
@@ -1165,6 +1165,7 @@ internal static class InitTemplates
                       Agent: Reviewer             # routes on keyword — NOT terminal
                     - Id: approved                # terminal node — session ends after this run
                       Agent: Reviewer             # same agent, terminal confirmation
+                      Terminal: true
 
                   # Edges define control flow — first matching edge fires each turn.
                   # Forward edges (target has higher BFS layer) use SendMessage within the

--- a/src/Cli/YamlConfigLoader.cs
+++ b/src/Cli/YamlConfigLoader.cs
@@ -59,6 +59,7 @@ internal static class YamlConfigLoader
     {
         var deserializer = new DeserializerBuilder()
             .WithNamingConvention(NullNamingConvention.Instance)
+            .WithAttemptingUnquotedStringTypeDeserialization()
             .Build();
 
         var graph = deserializer.Deserialize<object>(yaml);

--- a/src/Orchestration/Validation/RequireAllFilesWrittenValidator.cs
+++ b/src/Orchestration/Validation/RequireAllFilesWrittenValidator.cs
@@ -41,7 +41,6 @@ public sealed class RequireAllFilesWrittenValidator(
 
         // 3. Collect required file paths from brief.
         var required = brief?.FilesToChange?
-            .Select(f => f.Path)
             .Where(p => !string.IsNullOrWhiteSpace(p))
             .Select(p => PathHelpers.NormalizePath(p!))
             .ToList() ?? [];
@@ -207,11 +206,5 @@ public sealed class RequireAllFilesWrittenValidator(
 internal sealed record AllFilesWrittenBrief
 {
     [JsonPropertyName("files_to_change")]
-    public List<AllFilesWrittenBriefFile>? FilesToChange { get; init; }
-}
-
-internal sealed record AllFilesWrittenBriefFile
-{
-    [JsonPropertyName("path")]
-    public string? Path { get; init; }
+    public List<string>? FilesToChange { get; init; }
 }

--- a/src/Orchestration/Validation/RequireBriefValidator.cs
+++ b/src/Orchestration/Validation/RequireBriefValidator.cs
@@ -25,7 +25,6 @@ namespace fuseraft.Orchestration.Validation;
 ///   <item><c>goal</c> field is non-empty.</item>
 ///   <item><c>files_to_change</c> array is non-empty.</item>
 ///   <item><c>acceptance_criteria</c> array is non-empty.</item>
-///   <item><c>implementation</c> array is non-empty.</item>
 /// </list>
 /// </para>
 ///
@@ -51,7 +50,7 @@ public sealed class RequireBriefValidator(string briefPath) : IRoutingValidator
                 $"  1. Identify goal, constraints, acceptance criteria.\n" +
                 $"  2. Explore codebase with list_files/read_file.\n" +
                 $"  3. write_file '{briefPath}':\n" +
-                $"     {{ \"goal\": \"...\", \"files_to_change\": [{{\"path\": \"...\", \"reason\": \"...\"}}], \"acceptance_criteria\": [\"...\"], \"constraints\": [\"...\"], \"implementation\": [{{\"action\": \"write\", \"path\": \"...\", \"content\": \"...\"}}] }}\n" +
+                $"     {{ \"goal\": \"...\", \"files_to_change\": [\"path/to/file\"], \"acceptance_criteria\": [\"...\"], \"constraints\": [\"...\"] }}\n" +
                 $"  4. Call handoff(route_keyword: \"HANDOFF TO DEVELOPER\").");
 
         // 2. JSON validity
@@ -89,26 +88,16 @@ public sealed class RequireBriefValidator(string briefPath) : IRoutingValidator
                 $"HANDOFF TO DEVELOPER blocked: '{briefPath}' missing 'goal'. Add one sentence describing what to build." +
                 currentBriefNote);
 
-        // 4. files_to_change
+        // 4. files_to_change — plain string paths, e.g. ["src/foo.py", "tests/test_foo.py"]
         if (brief.FilesToChange is null or { Count: 0 })
             return RoutingValidationResult.Fail(
-                $"HANDOFF TO DEVELOPER blocked: '{briefPath}' has empty 'files_to_change'. List every file to create or modify." +
+                $"HANDOFF TO DEVELOPER blocked: '{briefPath}' has empty 'files_to_change'. List every file path to create or modify." +
                 currentBriefNote);
 
         // 5. acceptance_criteria
         if (brief.AcceptanceCriteria is null or { Count: 0 })
             return RoutingValidationResult.Fail(
                 $"HANDOFF TO DEVELOPER blocked: '{briefPath}' has empty 'acceptance_criteria'. Add at least one testable criterion." +
-                currentBriefNote);
-
-        // 6. implementation — must be present and non-empty so the Developer has
-        //    an executable spec rather than prose guidance to interpret.
-        if (brief.Implementation is null or { Count: 0 })
-            return RoutingValidationResult.Fail(
-                $"HANDOFF TO DEVELOPER blocked: '{briefPath}' has empty 'implementation'. Provide ordered changes:\n" +
-                $"  - action=write: full content for new/small files.\n" +
-                $"  - action=patch: exact old→new for large files.\n" +
-                $"Cover every file in files_to_change." +
                 currentBriefNote);
 
         return RoutingValidationResult.Pass();
@@ -123,20 +112,8 @@ internal sealed record BriefContent
     public string? Goal { get; init; }
 
     [JsonPropertyName("files_to_change")]
-    public List<BriefFileEntry>? FilesToChange { get; init; }
+    public List<string>? FilesToChange { get; init; }
 
     [JsonPropertyName("acceptance_criteria")]
     public List<string>? AcceptanceCriteria { get; init; }
-
-    [JsonPropertyName("implementation")]
-    public List<object>? Implementation { get; init; }
-}
-
-internal sealed record BriefFileEntry
-{
-    [JsonPropertyName("path")]
-    public string? Path { get; init; }
-
-    [JsonPropertyName("reason")]
-    public string? Reason { get; init; }
 }

--- a/tests/FuseraftCli.Tests/RequireAllFilesWrittenValidatorTests.cs
+++ b/tests/FuseraftCli.Tests/RequireAllFilesWrittenValidatorTests.cs
@@ -25,7 +25,7 @@ public sealed class RequireAllFilesWrittenValidatorTests : IDisposable
         var brief = new
         {
             goal = "build it",
-            files_to_change = filePaths.Select(p => new { path = p, reason = "needed" }),
+            files_to_change = filePaths,
             acceptance_criteria = new[] { "it works" }
         };
         await File.WriteAllTextAsync(BriefPath, JsonSerializer.Serialize(brief));

--- a/tests/FuseraftCli.Tests/RequireBriefValidatorTests.cs
+++ b/tests/FuseraftCli.Tests/RequireBriefValidatorTests.cs
@@ -49,7 +49,7 @@ public sealed class RequireBriefValidatorTests : IDisposable
     {
         await WriteJson(new
         {
-            files_to_change = new[] { new { path = "a.go", reason = "r" } },
+            files_to_change = new[] { "a.go" },
             acceptance_criteria = new[] { "it compiles" }
         });
 
@@ -65,7 +65,7 @@ public sealed class RequireBriefValidatorTests : IDisposable
         await WriteJson(new
         {
             goal = "   ",
-            files_to_change = new[] { new { path = "a.go", reason = "r" } },
+            files_to_change = new[] { "a.go" },
             acceptance_criteria = new[] { "it compiles" }
         });
 
@@ -114,7 +114,7 @@ public sealed class RequireBriefValidatorTests : IDisposable
         await WriteJson(new
         {
             goal = "build it",
-            files_to_change = new[] { new { path = "a.go", reason = "r" } }
+            files_to_change = new[] { "a.go" }
         });
 
         var result = await Validator().ValidateAsync(NoHistory);
@@ -129,7 +129,7 @@ public sealed class RequireBriefValidatorTests : IDisposable
         await WriteJson(new
         {
             goal = "build it",
-            files_to_change = new[] { new { path = "a.go", reason = "r" } },
+            files_to_change = new[] { "a.go" },
             acceptance_criteria = Array.Empty<string>()
         });
 
@@ -146,9 +146,8 @@ public sealed class RequireBriefValidatorTests : IDisposable
         await WriteJson(new
         {
             goal = "build a todo app",
-            files_to_change = new[] { new { path = "main.go", reason = "entry point" } },
-            acceptance_criteria = new[] { "app starts", "tasks persist" },
-            implementation = new[] { new { file = "main.go", action = "write", content = "package main" } }
+            files_to_change = new[] { "main.go" },
+            acceptance_criteria = new[] { "app starts", "tasks persist" }
         });
 
         var result = await Validator().ValidateAsync(NoHistory);
@@ -163,9 +162,8 @@ public sealed class RequireBriefValidatorTests : IDisposable
         await WriteJson(new
         {
             goal = "build it",
-            files_to_change = new[] { new { path = "a.go", reason = "r" } },
-            acceptance_criteria = new[] { "criterion" },
-            implementation = new[] { new { file = "a.go", action = "write", content = "x" } }
+            files_to_change = new[] { "a.go" },
+            acceptance_criteria = new[] { "criterion" }
         });
         var history = new List<ChatMessage>
         {


### PR DESCRIPTION
---

### Summary

- **YAML bool round-trip** (`c4114e6`): `YamlDotNet` was storing unquoted `true`/`false` as strings, causing `System.Text.Json` to reject fields typed as `bool` (e.g. `ContextWindow.TextOnly`). Enabled `WithAttemptingUnquotedStringTypeDeserialization` so scalars deserialize as their correct C# types.
- **Brief validator schema alignment** (`e9e2354`): `RequireBriefValidator` and `RequireAllFilesWrittenValidator` expected `files_to_change` as `[{path, reason}]` objects and required an `implementation` array, but the Planner template emits plain string paths with no `implementation` field. The mismatch caused the Planner to oscillate through four validation rounds before a sub-agent reverse-engineered the hidden schema. Reverted both validators to `List<string>`, dropped the dead object types, and removed the `implementation` check.
- **Missing `Terminal: true` on approved node** (`62a3aa6`): The graph init template was generating an approved node without `Terminal: true`, causing the orchestrator to loop indefinitely waiting for a routing keyword that could never be emitted. 
- **Tester fabricated-PASS prevention** (`3904e2f`): Tester agents were submitting PASS verdicts with empty `command` fields. Added the constraint — every PASS requires a non-empty command — to all init templates and example configs so agents see it before writing the report, rather than hitting it at handoff.
- **Dedicated `Approved` terminal agent** (`5859e16`): The `approved` terminal node reused the Reviewer agent, causing it to re-run the full spot-check protocol on every clean pass (~9,500 extra input tokens, ~17s). Both graph templates now generate a dedicated `approved.yaml` with `FunctionChoice: none`, no plugins, and a one-sentence confirmation instruction. 

### Test plan

- `fuseraft init --type graph` generates `agents/approved.yaml` with `FunctionChoice: none`
- Graph run completes without the Reviewer re-running at the terminal node
- `RequireBriefValidator` passes when `files_to_change` is a plain string list 
- Agent files with `ContextWindow: TextOnly: true` load without deserialization errors