### PR TITLE
docs: update test-report schema and dev-team template description

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -639,7 +639,7 @@ fuseraft init [output] [options]
 
 | Template | Description |
 |----------|-------------|
-| `dev-team` | Four-agent pipeline: Planner → Developer → Tester → Reviewer with keyword routing |
+| `dev-team` | Five-agent pipeline: Planner → Developer → Tester → Reviewer with keyword routing, plus a periodic Verifier that audits the evidence graph for inconsistencies |
 | `research` | Two-agent pipeline: Researcher gathers information, Writer produces the final report |
 | `devops` | Three-agent pipeline for infrastructure and deployment tasks |
 | `content` | Two-agent pipeline: Writer drafts, Editor refines and approves |

--- a/docs/validators.md
+++ b/docs/validators.md
@@ -349,7 +349,7 @@ The Tester must write a file at `Validation.TestReportPath` (default `.fuseraft/
 | `results[].status` | yes | `PASS` or `FAIL`. |
 | `results[].command` | yes (for PASS) | The exact shell command that was executed to verify this criterion. An empty command on a PASS result is rejected as fabricated. |
 | `results[].exit_code` | no | The actual exit code. Informational — not validated. |
-| `results[].stdout` | no | Omit this field. The Reviewer re-runs commands themselves; pre-recorded output is not used in validation and adds noise to the history. |
+| `results[].output` | yes (for FAIL) | Relevant stderr/stdout from the failing command. Required on FAIL results so the Developer can diagnose without re-running. Omit on PASS results — the Reviewer re-runs commands themselves and pre-recorded output adds noise to the history. |
 | `fake_test_files` | yes | List of test files that contain no real assertions. Must be empty for handoff to proceed. |
 
 ### Assertion pattern detection


### PR DESCRIPTION
validators.md: replace stale stdout guidance with output field (required on FAIL results — stderr/stdout for Developer diagnosis; omit on PASS).

cli-reference.md: correct dev-team agent count from four to five (Verifier is the fifth agent, runs periodically to audit the evidence graph).