### PR TITLE
Fix emoji rendering in MINGW64 terminals

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -14,7 +14,7 @@ using fuseraft.Core.Interfaces;
 using fuseraft.Infrastructure;
 using fuseraft.Infrastructure.Plugins;
 
-ConfigureWindowsConsoleEncoding();
+ConfigureConsoleEncoding();
 
 // Catch crashes on background threads (not covered by Spectre's SetExceptionHandler).
 AppDomain.CurrentDomain.UnhandledException += (_, e) =>
@@ -230,21 +230,11 @@ finally
     await Log.CloseAndFlushAsync();
 }
 
-static void ConfigureWindowsConsoleEncoding()
+static void ConfigureConsoleEncoding()
 {
-    if (!OperatingSystem.IsWindows()) return;
+    try { Console.OutputEncoding = Encoding.UTF8; }
+    catch (Exception ex) when (ex is IOException or NotSupportedException or UnauthorizedAccessException) { }
 
-    TrySetConsoleEncoding(() => Console.OutputEncoding = Encoding.UTF8);
-    TrySetConsoleEncoding(() => Console.InputEncoding = Encoding.UTF8);
-}
-
-static void TrySetConsoleEncoding(Action setEncoding)
-{
-    try
-    {
-        setEncoding();
-    }
-    catch (Exception ex) when (ex is IOException or NotSupportedException or UnauthorizedAccessException)
-    {
-    }
+    try { Console.InputEncoding = Encoding.UTF8; }
+    catch (Exception ex) when (ex is IOException or NotSupportedException or UnauthorizedAccessException) { }
 }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Text;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Serilog;
@@ -12,6 +13,8 @@ using fuseraft.Core;
 using fuseraft.Core.Interfaces;
 using fuseraft.Infrastructure;
 using fuseraft.Infrastructure.Plugins;
+
+ConfigureWindowsConsoleEncoding();
 
 // Catch crashes on background threads (not covered by Spectre's SetExceptionHandler).
 AppDomain.CurrentDomain.UnhandledException += (_, e) =>
@@ -225,4 +228,23 @@ try
 finally
 {
     await Log.CloseAndFlushAsync();
+}
+
+static void ConfigureWindowsConsoleEncoding()
+{
+    if (!OperatingSystem.IsWindows()) return;
+
+    TrySetConsoleEncoding(() => Console.OutputEncoding = Encoding.UTF8);
+    TrySetConsoleEncoding(() => Console.InputEncoding = Encoding.UTF8);
+}
+
+static void TrySetConsoleEncoding(Action setEncoding)
+{
+    try
+    {
+        setEncoding();
+    }
+    catch (Exception ex) when (ex is IOException or NotSupportedException or UnauthorizedAccessException)
+    {
+    }
 }


### PR DESCRIPTION
Closes #7

## Summary
- Configure Windows console input/output encoding to UTF-8 at CLI startup.
- Keep the encoding setup best-effort so unsupported console environments do not block startup.

## Verification
- `dotnet test` (461 passed; existing CS8669 nullable warning in `src/Cli/Commands/InitTemplates.Designer.cs`)
- `dotnet run --project src\FuseraftCli.csproj -- --version`