### PR TITLE
style: remove DevUIServer alignment padding

### DIFF
--- a/src/Cli/DevUI/DevUIServer.cs
+++ b/src/Cli/DevUI/DevUIServer.cs
@@ -20,8 +20,8 @@ namespace fuseraft.Cli.DevUI;
 /// </summary>
 public sealed class DevUIServer : IAsyncDisposable
 {
-    private const    int                        MaxHistoryEvents = 1_000;
-    private readonly Lock                      _lock    = new();
+    private const int MaxHistoryEvents = 1_000;
+    private readonly Lock _lock = new();
     private readonly List<string>              _history = [];
     private readonly List<ChannelWriter<string>> _clients = [];
 


### PR DESCRIPTION
## Summary

Removes stale alignment padding from the `MaxHistoryEvents` constant declaration in `DevUIServer` so the field declarations use normal spacing again.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Plugin
- [ ] Config example
- [ ] Documentation
- [x] Refactor / cleanup
- [ ] Other: <!-- describe -->

## Related issues

Fixes #22

## Changes

- normalized the `MaxHistoryEvents` constant declaration spacing
- removed matching alignment padding from the adjacent `_lock` field for consistency

## Testing

- [ ] Added or updated unit tests
- [ ] All tests pass locally (`./build.sh --target=Test`)
- [ ] Tested manually end-to-end
- [ ] Documentation updated where relevant
- [ ] `config/examples/` updated if config schema changed

Local verification was limited to direct file inspection. `dotnet test tests/FuseraftCli.Tests/FuseraftCli.Tests.csproj` is blocked on this runner because the repo targets .NET 10.0 while the available SDK is .NET 9.0.109 (`NETSDK1045`).

## Invariants

- [ ] Execution order unchanged (Selection → Validation → Failure handling → Termination → Iteration cap)
- [ ] Any new file/shell/git tool is wrapped by `ChangeTracker`
- [ ] Any new validator is deterministic, side-effect free, and idempotent
- [ ] Physical history is not stripped or reordered outside of compaction

## Notes for reviewers

- Scoped to formatting only; no behavior changes.
