### PR TITLE
fix: align truncation guard comment with threshold

### DIFF
--- a/src/Infrastructure/Plugins/FileSystemPlugin.cs
+++ b/src/Infrastructure/Plugins/FileSystemPlugin.cs
@@ -455,7 +455,7 @@ public sealed class FileSystemPlugin : ITurnResettable
         // would corrupt the file. Instead, return an error so the agent knows to use a
         // targeted edit tool (sed -i, or shell_run with a patch) rather than a full rewrite.
         //
-        // Threshold: if the existing file is > 400 lines AND the new content has fewer than
+        // Threshold: if the existing file is > 50 lines AND the new content has fewer than
         // 60 % of the existing line count, reject the write.
         if (File.Exists(resolved))
         {


### PR DESCRIPTION
## Summary

Updates the truncation-guard comment in `FileSystemPlugin` so it matches the actual `existingLines > 50` threshold used by the code.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Plugin
- [ ] Config example
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Other: <!-- describe -->

## Related issues

Fixes #17

## Changes

- changed the stale `> 400 lines` comment to `> 50 lines`
- left the guard logic untouched

## Testing

- [ ] Added or updated unit tests
- [ ] All tests pass locally (`./build.sh --target=Test`)
- [ ] Tested manually end-to-end
- [ ] Documentation updated where relevant
- [ ] `config/examples/` updated if config schema changed

Local verification was limited to direct file inspection. `dotnet test tests/FuseraftCli.Tests/FuseraftCli.Tests.csproj` is blocked on this runner because the repo targets .NET 10.0 while the available SDK is .NET 9.0.109 (`NETSDK1045`).

## Invariants

- [ ] Execution order unchanged (Selection → Validation → Failure handling → Termination → Iteration cap)
- [ ] Any new file/shell/git tool is wrapped by `ChangeTracker`
- [ ] Any new validator is deterministic, side-effect free, and idempotent
- [ ] Physical history is not stripped or reordered outside of compaction

## Notes for reviewers

- Comment-only fix; behavior is unchanged.
