### PR TITLE
fix: standardize missing source error wording

### DIFF
--- a/src/Infrastructure/Plugins/FileSystemPlugin.cs
+++ b/src/Infrastructure/Plugins/FileSystemPlugin.cs
@@ -750,7 +750,7 @@ public sealed class FileSystemPlugin : ITurnResettable
         if (dstDenial is not null) return dstDenial;
 
         if (!File.Exists(resolvedSrc))
-            return PluginResult.Error($"Source file not found: {resolvedSrc}");
+            return PluginResult.Error($"Source not found: {resolvedSrc}");
 
         if (!overwrite && File.Exists(resolvedDst))
             return PluginResult.Error($"Destination already exists: {resolvedDst}. Set overwrite=true to replace it.");


### PR DESCRIPTION
## Summary

Standardizes the missing-source error wording between the copy and move operations by using the same `Source not found` message in both paths.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Plugin
- [ ] Config example
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Other: <!-- describe -->

## Related issues

Fixes #19

## Changes

- updated `CopyFileAsync` to return the same missing-source wording already used by `MoveFileAsync`
- kept the existing overwrite and success paths unchanged

## Testing

- [ ] Added or updated unit tests
- [ ] All tests pass locally (`./build.sh --target=Test`)
- [ ] Tested manually end-to-end
- [ ] Documentation updated where relevant
- [ ] `config/examples/` updated if config schema changed

Local verification was limited to direct file inspection. `dotnet test tests/FuseraftCli.Tests/FuseraftCli.Tests.csproj` is blocked on this runner because the repo targets .NET 10.0 while the available SDK is .NET 9.0.109 (`NETSDK1045`).

## Invariants

- [ ] Execution order unchanged (Selection → Validation → Failure handling → Termination → Iteration cap)
- [ ] Any new file/shell/git tool is wrapped by `ChangeTracker`
- [ ] Any new validator is deterministic, side-effect free, and idempotent
- [ ] Physical history is not stripped or reordered outside of compaction

## Notes for reviewers

- Chosen wording is the existing generic form used by the move path, which also covers directory inputs.
