### PR TITLE
docs: add missing ChangeLog XML comments

### DIFF
--- a/src/Core/Models/ChangeLog.cs
+++ b/src/Core/Models/ChangeLog.cs
@@ -9,6 +9,7 @@ namespace fuseraft.Core.Models;
 /// </summary>
 public record ChangeLog
 {
+    /// <summary>All persisted per-turn change entries in chronological order.</summary>
     public List<ChangeEntry> Entries { get; init; } = [];
 
     /// <summary>
@@ -25,8 +26,11 @@ public record ChangeLog
 /// </summary>
 public record ChangeEntry
 {
+    /// <summary>Name of the agent that produced the recorded tool activity.</summary>
     public string Agent { get; init; } = string.Empty;
+    /// <summary>Zero-based turn index for the agent response that produced this entry.</summary>
     public int TurnIndex { get; init; }
+    /// <summary>UTC timestamp when the entry was recorded.</summary>
     public DateTime Timestamp { get; init; }
 
     /// <summary>Session that produced this entry. Null for entries written before session-ID stamping was introduced.</summary>
@@ -47,6 +51,7 @@ public record ChangeEntry
 
 public record CommandRecord
 {
+    /// <summary>Exact shell command that was executed.</summary>
     public string Command { get; init; } = string.Empty;
 
     [JsonPropertyName("succeeded")]


### PR DESCRIPTION
## Summary

Adds the missing XML documentation comments called out in `ChangeLog.cs` so the sibling properties have consistent API docs coverage.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Plugin
- [ ] Config example
- [x] Documentation
- [ ] Refactor / cleanup
- [ ] Other: <!-- describe -->

## Related issues

Fixes #20

## Changes

- documented `ChangeLog.Entries`
- documented `ChangeEntry.Agent`, `TurnIndex`, and `Timestamp`
- documented `CommandRecord.Command`

## Testing

- [ ] Added or updated unit tests
- [ ] All tests pass locally (`./build.sh --target=Test`)
- [ ] Tested manually end-to-end
- [x] Documentation updated where relevant
- [ ] `config/examples/` updated if config schema changed

Local verification was limited to direct file inspection. `dotnet test tests/FuseraftCli.Tests/FuseraftCli.Tests.csproj` is blocked on this runner because the repo targets .NET 10.0 while the available SDK is .NET 9.0.109 (`NETSDK1045`).

## Invariants

- [ ] Execution order unchanged (Selection → Validation → Failure handling → Termination → Iteration cap)
- [ ] Any new file/shell/git tool is wrapped by `ChangeTracker`
- [ ] Any new validator is deterministic, side-effect free, and idempotent
- [ ] Physical history is not stripped or reordered outside of compaction

## Notes for reviewers

- Documentation-only change; runtime behavior is unchanged.
