### PR TITLE
docs: clarify PluginResult fail vs error semantics

### DIFF
--- a/src/Infrastructure/Plugins/ProcessHelper.cs
+++ b/src/Infrastructure/Plugins/ProcessHelper.cs
@@ -221,11 +221,22 @@ internal readonly record struct ProcessResult(string Stdout, string Stderr, int 
 /// </summary>
 internal static class PluginResult
 {
-    public static string Ok(string message)       => $"[OK] {message}";
-    public static string Error(string message)    => $"[ERROR] {message}";
-    public static string Info(string message)     => $"[INFO] {message}";
-    public static string Denied(string message)   => $"[DENIED] {message}";
+    public static string Ok(string message) => $"[OK] {message}";
+
+    /// <summary>
+    /// Return an actionable usage or request error caused by the current tool call, such as
+    /// invalid arguments, unsupported inputs, or missing session state the caller can fix.
+    /// </summary>
+    public static string Error(string message) => $"[ERROR] {message}";
+
+    public static string Info(string message) => $"[INFO] {message}";
+    public static string Denied(string message) => $"[DENIED] {message}";
     public static string NotFound(string message) => $"[NOT FOUND] {message}";
-    public static string Timeout(string message)  => $"[TIMEOUT] {message}";
-    public static string Fail(string message)     => $"[FAIL] {message}";
+    public static string Timeout(string message) => $"[TIMEOUT] {message}";
+
+    /// <summary>
+    /// Return an environment or dependency failure where the request itself is valid but the
+    /// runtime cannot complete it until an external prerequisite is fixed.
+    /// </summary>
+    public static string Fail(string message) => $"[FAIL] {message}";
 }


### PR DESCRIPTION
## Summary

Documents the semantic distinction between `PluginResult.Error` and `PluginResult.Fail` in the shared `PluginResult` factory so call sites in `CodeExecutionPlugin` are easier to interpret.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Plugin
- [ ] Config example
- [x] Documentation
- [ ] Refactor / cleanup
- [ ] Other: <!-- describe -->

## Related issues

Fixes #21

## Changes

- added an XML doc comment to `PluginResult.Error` for caller-actionable request errors
- added an XML doc comment to `PluginResult.Fail` for valid requests blocked by missing runtime prerequisites
- normalized the small method block formatting while touching the factory

## Testing

- [ ] Added or updated unit tests
- [ ] All tests pass locally (`./build.sh --target=Test`)
- [ ] Tested manually end-to-end
- [x] Documentation updated where relevant
- [ ] `config/examples/` updated if config schema changed

Local verification was limited to direct file inspection. `dotnet test tests/FuseraftCli.Tests/FuseraftCli.Tests.csproj` is blocked on this runner because the repo targets .NET 10.0 while the available SDK is .NET 9.0.109 (`NETSDK1045`).

## Invariants

- [ ] Execution order unchanged (Selection → Validation → Failure handling → Termination → Iteration cap)
- [ ] Any new file/shell/git tool is wrapped by `ChangeTracker`
- [ ] Any new validator is deterministic, side-effect free, and idempotent
- [ ] Physical history is not stripped or reordered outside of compaction

## Notes for reviewers

- Scoped to documentation of the shared result vocabulary; no runtime behavior changed.
