### PR TITLE
Add adversarial orchestration mode (GAN-style generate → critique → revise)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,26 @@ flowchart LR
     Developer  -.->|"reports"| Manager
 ```
 
+...to adversarial pipelines where generator agents produce artifacts and critic agents review them with fresh, isolated context windows — no shared history, no inherited blind spots:
+
+```mermaid
+flowchart TD
+    Task((Task))
+    Planner["Planner\ngenerator"]
+    PlanReviewer["PlanReviewer\ncritic · isolated context"]
+    Developer["Developer\ngenerator"]
+    CodeReviewer["CodeReviewer\ncritic · isolated context"]
+    Done(["✓ Done"])
+
+    Task         --> Planner
+    Planner      -->|artifact| PlanReviewer
+    PlanReviewer -->|"APPROVED"| Developer
+    PlanReviewer -.->|revise| Planner
+    Developer    -->|artifact| CodeReviewer
+    CodeReviewer -->|"APPROVED"| Done
+    CodeReviewer -.->|revise| Developer
+```
+
 ---
 
 ## Quick start
@@ -101,6 +121,7 @@ fuseraft init
 # Or start from a built-in template
 fuseraft init --template dev-team --model claude-sonnet-4-6
 fuseraft init --template graph          # directed-graph pipeline with parallel fan-out
+fuseraft init --template adversarial    # GAN-style generate → critique → revise pipeline
 fuseraft init --template designer       # AI-assisted config designer
 
 # Run a session
@@ -159,7 +180,7 @@ The binary lands in `./bin/`.
 ## Features
 
 **Orchestration**
-- Five routing modes: keyword, state machine, declarative directed graph (with parallel fan-out/fan-in), LLM-based selection, and fully autonomous Magentic
+- Six routing modes: keyword, state machine, declarative directed graph (with parallel fan-out/fan-in), LLM-based selection, fully autonomous Magentic, and adversarial generate→critique→revise pipelines
 - Routing validators that block handoffs unless real evidence is present on disk — no hallucinated progress
 - Saga orchestration wraps any pipeline with compensating rollback if a step fails
 

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -526,6 +526,78 @@ For `Selection.Type: magentic`, the entire `Termination` section is ignored. Ses
 
 ---
 
+### adversarial
+
+A GAN-inspired pipeline where generator agents produce artifacts and critic agents review them in fully isolated context windows. Each stage runs a tight generate → critique → revise loop before the approved artifact is passed to the next stage.
+
+The defining property is the **context firewall**: the critic never sees the generator's reasoning chain, prior shared history, or any other session state. It receives only its own system instructions and the artifact under review. This produces independent feedback rather than rubber-stamping — the same mechanism that makes a fresh code reviewer more effective than an author self-reviewing their own work.
+
+```yaml
+Selection:
+  Type: adversarial
+  Adversarial:
+    Rounds: 3          # critique rounds per stage (generator gets Rounds-1 revision opportunities)
+    PassKeyword: "APPROVED"
+    Stages:
+      - Generator: Planner
+        Critic: PlanReviewer
+        Label: Planning
+
+      - Generator: Developer
+        Critic: CodeReviewer
+        Label: Implementation
+```
+
+**How it works**
+
+1. **Stage loop:** stages execute sequentially. The approved artifact from each stage is appended to a shared history that subsequent generators receive as prior context. Critics never see this history.
+2. **Initial generation:** the generator is invoked with its system instructions, any prior-stage artifacts, and the original task.
+3. **Critique round:** the critic is invoked with a fresh context — only its system instructions and the artifact. No shared history, no generator reasoning.
+4. **Pass check:** if the critic emits `PassKeyword` (default `APPROVED`) on its own line, the stage exits early and the artifact is promoted.
+5. **Revision:** if the critic rejects and rounds remain, the generator is re-invoked with its previous artifact and the critique injected as a user message. A new critique round follows.
+6. **Exhaustion:** if all `Rounds` are consumed without approval, the last reviewed artifact is promoted anyway (with a warning log and event) so the pipeline does not stall.
+
+**Rounds semantics**
+
+`Rounds` is the number of critique rounds per stage. With `Rounds: 3`:
+
+- Round 1 → critique → revise (round 1 < 3)
+- Round 2 → critique → revise (round 2 < 3)
+- Round 3 → critique → **no revision** (final round — the last critiqued artifact is promoted)
+
+The generator receives `Rounds - 1` revision opportunities. The promoted artifact is always the most recent one that was actually reviewed — not an unreviewed revision.
+
+**Agent instructions**
+
+Critic agents should be instructed to either approve or provide specific, actionable feedback — and nothing in between. The default template ships critics with instructions like:
+
+```
+If the artifact meets all requirements, respond with exactly:
+APPROVED
+
+Otherwise, list specific, actionable defects. Be precise — describe what is wrong and why.
+```
+
+Generator agents work as normal. On revision turns the orchestrator injects the critique as a user message so the generator knows exactly what to address.
+
+**`AdversarialConfig` fields**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `Stages` | array | — | **Required.** Ordered list of generator/critic stage pairs. |
+| `Rounds` | int | `3` | Maximum critique rounds per stage. Generator gets `Rounds - 1` revision opportunities. Must be ≥ 1. |
+| `PassKeyword` | string | `"APPROVED"` | Keyword the critic emits on its own line to approve the artifact and exit the stage early. Case-insensitive. |
+
+**`AdversarialStageConfig` fields**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `Generator` | string | — | **Required.** Name of the agent that produces and revises artifacts. Must match an agent name in `Agents`. |
+| `Critic` | string | — | **Required.** Name of the agent that reviews with a fresh context window. Must match an agent name in `Agents`. Must be distinct from `Generator`. |
+| `Label` | string | `"{Generator} → {Critic}"` | Human-readable label shown in event logs and message tags. |
+
+---
+
 ## Termination strategies
 
 Configured under `Termination.Type`. The run stops when any enabled strategy fires.
@@ -659,6 +731,21 @@ Magentic fits naturally when:
 
 Magentic is also more expensive than keyword routing per round: each inner-loop iteration makes at least two manager LLM calls (`magentic_ledger_update` + `magentic_select_speaker`) in addition to the participant's call.
 
+### Adversarial
+
+Use adversarial when **output quality matters more than throughput** and you want independent review rather than self-review. The context firewall is the key mechanism — because the critic receives no shared history, it cannot be influenced by the generator's framing or reasoning, and it approaches the artifact the way a real independent reviewer would.
+
+Adversarial fits naturally when:
+
+- You have a linear pipeline where each phase produces a discrete artifact (plan, code, document) that should be verified before the next phase begins
+- You want to catch issues that single-pass generation consistently misses: phantom dependencies, incomplete error handling, architectural deviations, placeholder tests
+- The quality of later stages depends heavily on the quality of earlier stages — adversarial stages enforce that dependency by only promoting approved artifacts
+- You can afford the additional LLM calls (each stage uses at least 2 calls per round: one generate, one critique)
+
+**What adversarial trades away:** dynamic routing and self-correction. The pipeline is fixed at config time — stages always execute in order. There are no loop-back edges between stages, no validator-gated handoffs, and no mechanism for a stage to signal that a prior stage needs to restart. Each stage is isolated. If a critic's feedback reveals a fundamental problem with a previous stage's artifact, the orchestrator has no mechanism to restart that stage — it promotes the best artifact the current stage produced and continues.
+
+Adversarial is also not a substitute for running real tests. A critic LLM reviewing code is a heuristic check, not a compiler or test suite. Use it alongside `RequireShellPass` validators in a keyword or graph pipeline if you need evidence-gated progression.
+
 ### Graph
 
 Use graph when you need **explicit back-edge topology** — when different failure modes should route back to different prior nodes, or when you want the routing structure to be visible in the config rather than implied by keyword conventions.
@@ -676,19 +763,20 @@ Graph and keyword routing use the same `handoff()` plugin for typed signalling, 
 
 ---
 
-## Choosing between keyword, state machine, structured, and graph
+## Choosing between keyword, state machine, structured, graph, and adversarial
 
-| | Keyword | State machine | Structured | Graph |
-|---|---|---|---|---|
-| Handoff signal | Keyword on own line (relaxed) | Signal on own line (same as keyword) | JSON field value | Keyword alone on own line (strict) |
-| Evidence gating | Validators (per-route) | Contracts (per-transition, typed) | Instructions only | Validators (per-edge) |
-| Routing topology | All routes active at once | Only current state's transitions active | All routes active at once | Only current node's edges active |
-| Ghost signals | Possible — any agent can emit any keyword | Impossible — wrong-state signals are ignored | N/A | Reduced — wrong-node keywords are ignored |
-| Multi-target back-edges | Implicit (keyword scan order) | N/A (no back-edges) | N/A | Explicit — each back-edge has a distinct target node |
-| Lossless compaction | No | Yes (requires EvidenceStore) | No | No |
-| Verifier integration | No | Yes | No | No |
-| Failure classification | Yes | Yes | No | Yes |
-| Best for | Phased pipelines, dev teams | Same + hallucination-resistant routing | Classifiers, triage | Explicit multi-target loop-back topology |
+| | Keyword | State machine | Structured | Graph | Adversarial |
+|---|---|---|---|---|---|
+| Handoff signal | Keyword on own line (relaxed) | Signal on own line (same as keyword) | JSON field value | Keyword alone on own line (strict) | PassKeyword from critic |
+| Evidence gating | Validators (per-route) | Contracts (per-transition, typed) | Instructions only | Validators (per-edge) | None (critic LLM only) |
+| Routing topology | All routes active at once | Only current state's transitions active | All routes active at once | Only current node's edges active | Fixed sequential stages |
+| Ghost signals | Possible — any agent can emit any keyword | Impossible — wrong-state signals are ignored | N/A | Reduced — wrong-node keywords are ignored | N/A — critic approval is the only signal |
+| Multi-target back-edges | Implicit (keyword scan order) | N/A (no back-edges) | N/A | Explicit — each back-edge has a distinct target node | No back-edges between stages |
+| Critic context isolation | No | No | No | No | Yes — critics receive no shared history |
+| Lossless compaction | No | Yes (requires EvidenceStore) | No | No | No |
+| Verifier integration | No | Yes | No | No | No |
+| Failure classification | Yes | Yes | No | Yes | No |
+| Best for | Phased pipelines, dev teams | Same + hallucination-resistant routing | Classifiers, triage | Explicit multi-target loop-back topology | Quality gates on discrete artifacts |
 
 For a human-like team of roles (Planner, Developer, Tester, Reviewer):
 - Start with **keyword** if you want a simple, validator-gated pipeline quickly
@@ -696,6 +784,8 @@ For a human-like team of roles (Planner, Developer, Tester, Reviewer):
 - Choose **graph** when different failure outcomes must route back to different nodes and you want that topology explicit in the config
 
 For a pipeline where an agent computes a value and routing follows from it, prefer **structured**. The JSON is already the output — the routing field costs nothing to add.
+
+For a linear pipeline where each phase produces a discrete artifact (plan, code, document) and you want independent review between phases, prefer **adversarial**. The context firewall is the key mechanism — critics approach the artifact with no inherited assumptions from the generator.
 
 ---
 

--- a/src/Cli/Commands/InitTemplates.Adversarial.cs
+++ b/src/Cli/Commands/InitTemplates.Adversarial.cs
@@ -1,0 +1,114 @@
+using fuseraft.Core;
+
+namespace fuseraft.Cli.Commands;
+
+public static partial class InitTemplates
+{
+    /// <summary>
+    /// Generates the <c>adversarial</c> template: a GAN-style pipeline where generator agents
+    /// produce artifacts and critic agents review them in isolated context windows.
+    /// Each stage runs up to <c>Rounds</c> generate → critique → revise cycles before the
+    /// approved artifact is promoted to the next stage.
+    /// </summary>
+    private static string Adversarial(string model, string? endpoint) => $"""
+        Orchestration:
+          Name: Adversarial Pipeline
+          Description: >
+            GAN-style multi-agent pipeline. Generator agents produce artifacts; critic agents
+            review them with fresh, isolated context windows (no shared history). Each stage
+            runs up to Rounds generate → critique → revise cycles before the artifact is promoted.
+
+          Agents:
+            - Name: Planner
+              Description: Produces a step-by-step implementation plan from the task description.
+              Instructions: |
+                You are a Planner. Given a task, produce a clear, concrete, step-by-step
+                implementation plan. Be specific about what needs to be done, in what order,
+                and what the expected output of each step is. Avoid vague instructions.
+              Model:
+                ModelId: {model}{Ep(endpoint, "        ")}
+              Plugins:
+                - FileSystem
+                - Scratchpad
+
+            - Name: PlanReviewer
+              Description: Independently reviews a plan for logical flaws, gaps, and ambiguities.
+              Instructions: |
+                You are a PlanReviewer. You will receive a plan to review. Assess it critically:
+                - Are the steps logically ordered with no missing dependencies?
+                - Is each step concrete and actionable?
+                - Are there any ambiguities, contradictions, or dead-ends?
+                - Does the plan actually accomplish the stated goal?
+
+                If the plan is sound and complete, respond with exactly:
+                APPROVED
+
+                Otherwise, list specific, actionable improvements. Be precise — point to the
+                exact steps that need to change and explain why.
+              Model:
+                ModelId: {model}{Ep(endpoint, "        ")}
+
+            - Name: Developer
+              Description: Implements code based on an approved plan.
+              Instructions: |
+                You are a Developer. You will receive an approved plan and must implement it.
+                Write clean, working code. Use your tools to create files and run tests.
+                Report what you built and confirm it works.
+              Model:
+                ModelId: {model}{Ep(endpoint, "        ")}
+              Plugins:
+                - FileSystem
+                - Shell
+                - Git
+                - Scratchpad
+
+            - Name: CodeReviewer
+              Description: Independently reviews implemented code for correctness and quality.
+              Instructions: |
+                You are a CodeReviewer. You will receive implemented code to review.
+                Assess it critically with no assumptions about the author's intent:
+                - Does the implementation match the plan?
+                - Are there bugs, edge cases, or missing error handling?
+                - Is the code readable and maintainable?
+                - Do the tests cover the important paths?
+
+                If the implementation is correct and complete, respond with exactly:
+                APPROVED
+
+                Otherwise, list specific, actionable defects. Reference exact file paths and
+                line numbers where possible. Be precise — describe what is wrong and why.
+              Model:
+                ModelId: {model}{Ep(endpoint, "        ")}
+              Plugins:
+                - FileSystem
+
+          Selection:
+            Type: adversarial
+            Adversarial:
+              Rounds: 3          # critique rounds per stage (generator gets Rounds-1 revision opportunities)
+              PassKeyword: "APPROVED"
+              Stages:
+                - Generator: Planner
+                  Critic: PlanReviewer
+                  Label: Planning
+
+                - Generator: Developer
+                  Critic: CodeReviewer
+                  Label: Implementation
+
+          Termination:
+            Type: maxiterations
+            MaxIterations: 50
+
+          Compaction:
+            TriggerTurnCount: 40
+            KeepRecentTurns: 10
+
+          Checkpoint:
+            Mode: json
+            Path: .fuseraft/checkpoints
+
+          Events:
+            Path: {FuseraftPaths.LocalEventsLog}
+        """;
+}

--- a/src/Cli/Commands/InitTemplates.cs
+++ b/src/Cli/Commands/InitTemplates.cs
@@ -33,6 +33,7 @@ public static partial class InitTemplates
             "brownfield" => Brownfield(model, endpoint),
             "graph"            => Graph(model, endpoint),
             "brownfield-graph" => BrownfieldGraph(model, endpoint),
+            "adversarial"      => GeneratedConfig.Inline(Adversarial(model, endpoint)),
             _                  => DevTeam(model, endpoint),
         };
 

--- a/src/Cli/Commands/ValidateConfigCommand.cs
+++ b/src/Cli/Commands/ValidateConfigCommand.cs
@@ -180,7 +180,7 @@ public sealed class ValidateConfigCommand(PluginRegistry pluginRegistry) : Async
 
         // Selection strategy
         var selType = config.Selection.Type.ToLowerInvariant();
-        if (selType is not ("sequential" or "roundrobin" or "llm" or "keyword" or "structured" or "magentic" or "statemachine" or "graph"))
+        if (selType is not ("sequential" or "roundrobin" or "llm" or "keyword" or "structured" or "magentic" or "statemachine" or "graph" or "adversarial"))
             issues.Add(("error", $"Unknown selection type: '{config.Selection.Type}'."));
 
         if (selType == "llm" && config.Selection.Model is null)
@@ -200,6 +200,9 @@ public sealed class ValidateConfigCommand(PluginRegistry pluginRegistry) : Async
 
         if (selType == "statemachine")
             ValidateStateMachine(config, issues);
+
+        if (selType == "adversarial")
+            ValidateAdversarialSelection(config, issues);
 
         if (selType == "keyword" && config.Selection.Routes is { Count: > 1 })
         {
@@ -481,6 +484,56 @@ public sealed class ValidateConfigCommand(PluginRegistry pluginRegistry) : Async
 
             if (!string.IsNullOrWhiteSpace(edge.RecoveryAgent) && !agentNames.Contains(edge.RecoveryAgent))
                 issues.Add(("warning", $"{prefix}: RecoveryAgent '{edge.RecoveryAgent}' is not defined in Agents."));
+        }
+    }
+
+    private static void ValidateAdversarialSelection(
+        OrchestrationConfig config,
+        List<(string Level, string Message)> issues)
+    {
+        var adv = config.Selection.Adversarial;
+
+        if (adv is null)
+        {
+            issues.Add(("error",
+                "Selection.Type 'adversarial' requires a 'Selection.Adversarial' configuration block."));
+            return;
+        }
+
+        if (adv.Stages.Count == 0)
+        {
+            issues.Add(("error", "Selection.Adversarial.Stages must contain at least one stage."));
+            return;
+        }
+
+        if (adv.Rounds < 1)
+            issues.Add(("error",
+                $"Selection.Adversarial.Rounds must be at least 1 (got {adv.Rounds})."));
+
+        if (string.IsNullOrWhiteSpace(adv.PassKeyword))
+            issues.Add(("error", "Selection.Adversarial.PassKeyword must be a non-empty string."));
+
+        var agentNames = config.Agents.Select(a => a.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        for (int si = 0; si < adv.Stages.Count; si++)
+        {
+            var stage  = adv.Stages[si];
+            var prefix = $"Selection.Adversarial.Stages[{si}]";
+
+            if (string.IsNullOrWhiteSpace(stage.Generator))
+                issues.Add(("error", $"{prefix}: Generator is required."));
+            else if (!agentNames.Contains(stage.Generator))
+                issues.Add(("error", $"{prefix}.Generator '{stage.Generator}' is not defined in Orchestration.Agents."));
+
+            if (string.IsNullOrWhiteSpace(stage.Critic))
+                issues.Add(("error", $"{prefix}: Critic is required."));
+            else if (!agentNames.Contains(stage.Critic))
+                issues.Add(("error", $"{prefix}.Critic '{stage.Critic}' is not defined in Orchestration.Agents."));
+
+            if (!string.IsNullOrWhiteSpace(stage.Generator) && !string.IsNullOrWhiteSpace(stage.Critic) &&
+                string.Equals(stage.Generator, stage.Critic, StringComparison.OrdinalIgnoreCase))
+                issues.Add(("warning",
+                    $"{prefix}: Generator and Critic are the same agent ('{stage.Generator}'). " +
+                    "Self-critique defeats the context firewall — use two distinct agents."));
         }
     }
 

--- a/src/Cli/Diagram/WorkflowDiagramGenerator.cs
+++ b/src/Cli/Diagram/WorkflowDiagramGenerator.cs
@@ -47,6 +47,9 @@ public static class WorkflowDiagramGenerator
             case "statemachine" when config.Selection.StateMachine is not null:
                 RenderStateMachine(sb, config.Selection.StateMachine);
                 break;
+            case "adversarial" when config.Selection.Adversarial is not null:
+                RenderAdversarial(sb, config.Selection.Adversarial);
+                break;
             default:
                 RenderGeneric(sb, config);
                 break;
@@ -280,6 +283,39 @@ public static class WorkflowDiagramGenerator
                 var arrow = label.Length > 0 ? $"-->|\"{label}\"| " : "--> ";
                 sb.AppendLine($"  {from} {arrow}{to}");
             }
+        }
+    }
+
+    private static void RenderAdversarial(StringBuilder sb, fuseraft.Core.Models.AdversarialConfig adv)
+    {
+        sb.AppendLine();
+        sb.AppendLine("  Task([Task])");
+
+        for (int i = 0; i < adv.Stages.Count; i++)
+        {
+            var stage   = adv.Stages[i];
+            var label   = stage.Label ?? $"{stage.Generator} → {stage.Critic}";
+            var genId   = $"gen{i}";
+            var critId  = $"crit{i}";
+            var passId  = $"pass{i}";
+
+            sb.AppendLine($"  {genId}[\"{Esc(stage.Generator)}\"]");
+            sb.AppendLine($"  {critId}[\"{Esc(stage.Critic)}\n(critic)\"]");
+            sb.AppendLine($"  {passId}([\"{Esc(label)} approved\"])");
+
+            if (i == 0)
+                sb.AppendLine($"  Task --> {genId}");
+            else
+                sb.AppendLine($"  pass{i - 1} --> {genId}");
+
+            sb.AppendLine($"  {genId} -->|artifact| {critId}");
+            sb.AppendLine($"  {critId} -->|\"{adv.PassKeyword}\"| {passId}");
+            sb.AppendLine($"  {critId} -->|revise| {genId}");
+        }
+
+        if (adv.Stages.Count > 0)
+        {
+            sb.AppendLine($"  pass{adv.Stages.Count - 1} --> Done([Done])");
         }
     }
 

--- a/src/Cli/OrchestratorBuilder.cs
+++ b/src/Cli/OrchestratorBuilder.cs
@@ -418,6 +418,56 @@ public static class OrchestratorBuilder
             }
         }
 
+        // Eagerly validate the adversarial config when that strategy is selected.
+        if (config.Selection.Type.Equals("adversarial", StringComparison.OrdinalIgnoreCase))
+        {
+            if (config.Selection.Adversarial is null)
+                throw new InvalidOperationException(
+                    "Selection.Type 'adversarial' requires a 'Selection.Adversarial' configuration block.");
+
+            var advCfg = config.Selection.Adversarial;
+
+            if (advCfg.Stages.Count == 0)
+                throw new InvalidOperationException(
+                    "Selection.Adversarial.Stages must contain at least one stage.");
+
+            if (advCfg.Rounds < 1)
+                throw new InvalidOperationException(
+                    $"Selection.Adversarial.Rounds must be at least 1 (got {advCfg.Rounds}).");
+
+            if (string.IsNullOrWhiteSpace(advCfg.PassKeyword))
+                throw new InvalidOperationException(
+                    "Selection.Adversarial.PassKeyword must be a non-empty string.");
+
+            var agentNames = config.Agents.Select(a => a.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+            for (int si = 0; si < advCfg.Stages.Count; si++)
+            {
+                var stage = advCfg.Stages[si];
+                if (string.IsNullOrWhiteSpace(stage.Generator))
+                    throw new InvalidOperationException(
+                        $"Selection.Adversarial.Stages[{si}]: Generator must be a non-empty agent name.");
+                if (!agentNames.Contains(stage.Generator))
+                    throw new InvalidOperationException(
+                        $"Selection.Adversarial.Stages[{si}].Generator '{stage.Generator}' " +
+                        "is not defined in 'Orchestration.Agents'.");
+                if (string.IsNullOrWhiteSpace(stage.Critic))
+                    throw new InvalidOperationException(
+                        $"Selection.Adversarial.Stages[{si}]: Critic must be a non-empty agent name.");
+                if (!agentNames.Contains(stage.Critic))
+                    throw new InvalidOperationException(
+                        $"Selection.Adversarial.Stages[{si}].Critic '{stage.Critic}' " +
+                        "is not defined in 'Orchestration.Agents'.");
+            }
+        }
+
+        // Warn when Selection.Adversarial is configured but Selection.Type is not "adversarial".
+        if (config.Selection.Adversarial is not null &&
+            !config.Selection.Type.Equals("adversarial", StringComparison.OrdinalIgnoreCase))
+            loggerFactory.CreateLogger(nameof(OrchestratorBuilder)).LogWarning(
+                "Selection.Adversarial is configured but Selection.Type is '{Type}', not 'adversarial'. " +
+                "The Adversarial block will be ignored. Set Selection.Type: adversarial to enable it.",
+                config.Selection.Type);
+
         // Eagerly validate the Magentic manager model and loop-counter config when that strategy is selected.
         if (config.Selection.Type.Equals("magentic", StringComparison.OrdinalIgnoreCase))
         {
@@ -484,8 +534,9 @@ public static class OrchestratorBuilder
         var aoLogger          = loggerFactory.CreateLogger<AgentOrchestrator>();
         var goLogger          = loggerFactory.CreateLogger<GraphOrchestrator>();
 
-        bool useMagentic = config.Selection.Type.Equals("magentic", StringComparison.OrdinalIgnoreCase);
-        bool useGraph    = config.Selection.Type.Equals("graph",    StringComparison.OrdinalIgnoreCase);
+        bool useMagentic    = config.Selection.Type.Equals("magentic",    StringComparison.OrdinalIgnoreCase);
+        bool useGraph       = config.Selection.Type.Equals("graph",       StringComparison.OrdinalIgnoreCase);
+        bool useAdversarial = config.Selection.Type.Equals("adversarial", StringComparison.OrdinalIgnoreCase);
 
         ConversationCompactor? compactor = null;
         if (config.Compaction is { } compactionConfig)
@@ -505,10 +556,11 @@ public static class OrchestratorBuilder
                     $"less than Compaction.TriggerTurnCount ({compactionConfig.TriggerTurnCount}).");
 
             var summaryModel = compactionConfig.Model ?? config.Agents[0].Model;
-            // Magentic sessions have no brief.json or change log, so the workflow-specific
-            // resumption note is suppressed to avoid agents wasting tokens on missing files.
-            var resumptionNote = useMagentic ? null : ConversationCompactor.WorkflowResumptionNote;
-            var changeLogPath  = useMagentic ? null
+            // Magentic and adversarial sessions have no brief.json or change log, so the
+            // workflow-specific resumption note is suppressed to avoid wasting tokens.
+            bool suppressResumptionNote = useMagentic || useAdversarial;
+            var resumptionNote = suppressResumptionNote ? null : ConversationCompactor.WorkflowResumptionNote;
+            var changeLogPath  = suppressResumptionNote ? null
                 : (config.Validation?.ChangeLogPath ?? config.ChangeTracking?.Path);
             compactor = new ConversationCompactor(
                 chatClientFactory.Create(summaryModel), compactionConfig,
@@ -550,6 +602,9 @@ public static class OrchestratorBuilder
         //
         // GraphOrchestrator handles the "graph" selection type: declarative directed-graph
         // execution with per-node agents, keyword-driven edges, and optional back-edges.
+        //
+        // AdversarialOrchestrator handles the "adversarial" selection type: GAN-style
+        // generate → critique → revise loops where critics receive isolated context windows.
         //
         // AgentOrchestrator is the general-purpose path: it drives any selection strategy
         // (sequential, llm, keyword, structured) through StrategyFactory and works with
@@ -694,6 +749,14 @@ public static class OrchestratorBuilder
         {
             orchestrator = new GraphOrchestrator(
                 config, agentFactory, goLogger,
+                changeTracker, eventEmitter, governanceKernel,
+                hitlMode ? humanApprovalService : null);
+        }
+        else if (useAdversarial)
+        {
+            var advLogger = loggerFactory.CreateLogger<AdversarialOrchestrator>();
+            orchestrator  = new AdversarialOrchestrator(
+                config, agentFactory, advLogger,
                 changeTracker, eventEmitter, governanceKernel,
                 hitlMode ? humanApprovalService : null);
         }

--- a/src/Core/Models/AdversarialConfig.cs
+++ b/src/Core/Models/AdversarialConfig.cs
@@ -1,0 +1,78 @@
+namespace fuseraft.Core.Models;
+
+/// <summary>
+/// Configuration for the adversarial orchestration mode (Selection.Type: "adversarial").
+///
+/// <para>
+/// Applies GAN-style generate → critique → revise loops to multi-agent pipelines.
+/// Each <see cref="AdversarialStageConfig"/> pairs a generator agent with a critic agent.
+/// The critic always receives a fresh, isolated context window — it sees only its own system
+/// instructions and the artifact to review, never the generator's reasoning history.
+/// </para>
+///
+/// <para>
+/// Stages run sequentially. The final artifact from each stage is appended to a shared
+/// history that subsequent generators can build on, but critics never see this history.
+/// </para>
+///
+/// Example YAML:
+/// <code>
+/// Selection:
+///   Type: adversarial
+///   Adversarial:
+///     Rounds: 3          # 3 critiques; generator gets 2 revision opportunities
+///     PassKeyword: "APPROVED"
+///     Stages:
+///       - Generator: Planner
+///         Critic: PlanReviewer
+///         Label: Planning
+///       - Generator: Developer
+///         Critic: CodeReviewer
+///         Label: Implementation
+/// </code>
+/// </summary>
+public record AdversarialConfig
+{
+    /// <summary>
+    /// Ordered list of generator/critic stage pairs. Stages execute sequentially; the
+    /// approved artifact from each stage is passed as context to the next generator.
+    /// </summary>
+    public List<AdversarialStageConfig> Stages { get; init; } = [];
+
+    /// <summary>
+    /// Maximum number of critique rounds per stage. The critic runs up to this many times;
+    /// the generator gets up to <c>Rounds - 1</c> revision opportunities (the final critique
+    /// round never triggers a revision, so the last reviewed artifact is always what gets
+    /// promoted). Must be at least 1. Defaults to 3.
+    /// </summary>
+    public int Rounds { get; init; } = 3;
+
+    /// <summary>
+    /// Keyword the critic must emit on its own line (case-insensitive) to signal that the
+    /// current artifact has passed review. When found the stage exits early and the artifact
+    /// is promoted to the next stage without consuming remaining rounds. Defaults to "APPROVED".
+    /// </summary>
+    public string PassKeyword { get; init; } = "APPROVED";
+}
+
+/// <summary>A single generator/critic pair within an adversarial pipeline.</summary>
+public record AdversarialStageConfig
+{
+    /// <summary>
+    /// Name of the agent that produces and revises the artifact. Must match a name in
+    /// <c>Orchestration.Agents</c>.
+    /// </summary>
+    public string Generator { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Name of the agent that reviews the artifact with a fresh context window. Must match
+    /// a name in <c>Orchestration.Agents</c>.
+    /// </summary>
+    public string Critic { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Human-readable label for this stage. Used in event logs and message tags.
+    /// Defaults to "{Generator} → {Critic}" when null.
+    /// </summary>
+    public string? Label { get; init; }
+}

--- a/src/Core/Models/StrategyConfig.cs
+++ b/src/Core/Models/StrategyConfig.cs
@@ -77,6 +77,19 @@ public record SelectionStrategyConfig
     /// </para>
     /// </summary>
     public GraphConfig? Graph { get; init; }
+
+    /// <summary>
+    /// Adversarial pipeline configuration for the <c>adversarial</c> selection type.
+    /// Required when <see cref="Type"/> is <c>"adversarial"</c>.
+    ///
+    /// <para>
+    /// Each stage pairs a generator agent with a critic agent. The critic always receives
+    /// a fresh, isolated context window — it sees only the artifact under review, never the
+    /// generator's reasoning history. Stages run sequentially; the approved artifact from
+    /// each stage feeds the next generator.
+    /// </para>
+    /// </summary>
+    public AdversarialConfig? Adversarial { get; init; }
 }
 
 /// <summary>

--- a/src/Orchestration/AdversarialOrchestrator.cs
+++ b/src/Orchestration/AdversarialOrchestrator.cs
@@ -1,0 +1,460 @@
+using System.Runtime.CompilerServices;
+using AgentGovernance;
+using AgentGovernance.Sre;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using fuseraft.Core;
+using fuseraft.Core.Interfaces;
+using fuseraft.Core.Models;
+
+// Disambiguate from Microsoft.Agents.AI.AgentFactory
+using fuseraft.Infrastructure;
+using AgentFactory = fuseraft.Infrastructure.AgentFactory;
+
+namespace fuseraft.Orchestration;
+
+/// <summary>
+/// Adversarial orchestrator — applies GAN-style generate → critique → revise loops.
+/// Activated by <c>Selection.Type: "adversarial"</c>.
+///
+/// <para>
+/// <b>Stages</b>: each <see cref="AdversarialStageConfig"/> pairs a generator agent with
+/// a critic agent. Stages run sequentially; the approved artifact from each stage is
+/// appended to a shared history that subsequent generators receive as prior context.
+/// </para>
+///
+/// <para>
+/// <b>Context firewall</b>: the critic always invokes with a fresh context window
+/// containing only its own system instructions and the artifact under review. It never
+/// sees the generator's reasoning chain or prior shared history. This is the mechanism
+/// that produces genuine independent review rather than rubber-stamping.
+/// </para>
+///
+/// <para>
+/// <b>Loop</b>: within each stage the orchestrator runs up to
+/// <see cref="AdversarialConfig.Rounds"/> generate/critique cycles. When the critic emits
+/// <see cref="AdversarialConfig.PassKeyword"/> on its own line the stage exits early and
+/// the artifact is promoted. If all rounds are exhausted the last artifact is promoted
+/// regardless so the pipeline continues.
+/// </para>
+/// </summary>
+public sealed class AdversarialOrchestrator(
+    OrchestrationConfig config,
+    AgentFactory agentFactory,
+    ILogger<AdversarialOrchestrator> logger,
+    ChangeTracker? changeTracker = null,
+    EventEmitter? eventEmitter = null,
+    GovernanceKernel? governanceKernel = null,
+    IHumanApprovalService? approvalService = null) : IOrchestrator
+{
+    private readonly AdversarialConfig _advConfig =
+        config.Selection.Adversarial ?? new AdversarialConfig();
+
+    // Reserved for future HITL integration (e.g. require human approval before stage promotion).
+    private readonly IHumanApprovalService? _approvalService = approvalService;
+
+    private string _sessionId = string.Empty;
+
+    // IOrchestrator events
+
+    public event Action<string>? AgentStarting;
+    public event Action<string, string, string?>? ToolCalling;
+    public event Action<string, int, int>? TokenBudgetWarning;
+
+    public void SetSessionId(string sessionId) => _sessionId = sessionId;
+
+    public async Task<OrchestrationResult> RunAsync(
+        string task,
+        IReadOnlyList<AgentMessage>? priorHistory = null,
+        CancellationToken cancellationToken = default)
+    {
+        var messages = new List<AgentMessage>();
+        var start    = DateTime.UtcNow;
+
+        try
+        {
+            await foreach (var msg in StreamAsync(task, priorHistory, cancellationToken).ConfigureAwait(false))
+                messages.Add(msg);
+
+            return new OrchestrationResult
+            {
+                SessionId         = _sessionId,
+                Succeeded         = true,
+                Messages          = messages,
+                Duration          = DateTime.UtcNow - start,
+                TerminationReason = "Completed"
+            };
+        }
+        catch (BudgetExceededException ex)
+        {
+            return new OrchestrationResult
+            {
+                SessionId         = _sessionId,
+                Succeeded         = false,
+                Messages          = messages,
+                Duration          = DateTime.UtcNow - start,
+                TerminationReason = "TokenBudgetExceeded",
+                ErrorMessage      = ex.Message
+            };
+        }
+        catch (OperationCanceledException)
+        {
+            return new OrchestrationResult
+            {
+                SessionId         = _sessionId,
+                Succeeded         = false,
+                Messages          = messages,
+                Duration          = DateTime.UtcNow - start,
+                TerminationReason = "Cancelled",
+                ErrorMessage      = "Operation was cancelled."
+            };
+        }
+        catch (Exception ex)
+        {
+            return new OrchestrationResult
+            {
+                SessionId         = _sessionId,
+                Succeeded         = false,
+                Messages          = messages,
+                Duration          = DateTime.UtcNow - start,
+                TerminationReason = "Error",
+                ErrorMessage      = ex.Message
+            };
+        }
+    }
+
+    public async IAsyncEnumerable<AgentMessage> StreamAsync(
+        string task,
+        IReadOnlyList<AgentMessage>? priorHistory = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        if (_advConfig.Stages.Count == 0)
+            throw new InvalidOperationException("Adversarial config has no stages defined.");
+
+        // Build all agents once; re-use across stages.
+        var agents = config.Agents
+            .Select(a => agentFactory.Create(a, onToolCalling: (agent, tool, args) => ToolCalling?.Invoke(agent, tool, args)))
+            .ToDictionary(a => a.Name!, StringComparer.OrdinalIgnoreCase);
+        var agentInstructions = config.Agents
+            .Where(a => !string.IsNullOrWhiteSpace(a.Instructions))
+            .ToDictionary(a => a.Name, a => a.Instructions, StringComparer.OrdinalIgnoreCase);
+
+        int turn             = priorHistory is { Count: > 0 } ? priorHistory[^1].TurnIndex + 1 : 0;
+        int cumulativeTokens = 0;
+
+        // Shared history: prior-stage approved artifacts accumulated for subsequent generators.
+        // Critics never see this list — they always receive a fresh, isolated context.
+        var sharedHistory = new List<ChatMessage>();
+
+        for (int stageIndex = 0; stageIndex < _advConfig.Stages.Count; stageIndex++)
+        {
+            var stage = _advConfig.Stages[stageIndex];
+            var label = stage.Label ?? $"{stage.Generator} → {stage.Critic}";
+            var stageTag = $"[Adversarial:Stage{stageIndex + 1}:{label}]";
+
+            if (!agents.TryGetValue(stage.Generator, out var generator))
+                throw new InvalidOperationException(
+                    $"Adversarial stage '{label}': generator agent '{stage.Generator}' not found in config.");
+            if (!agents.TryGetValue(stage.Critic, out var critic))
+                throw new InvalidOperationException(
+                    $"Adversarial stage '{label}': critic agent '{stage.Critic}' not found in config.");
+
+            agentInstructions.TryGetValue(stage.Generator, out var generatorInstructions);
+            agentInstructions.TryGetValue(stage.Critic,    out var criticInstructions);
+
+            logger.LogInformation(
+                "[AdversarialOrchestrator] Stage {Index}/{Total} '{Label}' starting.",
+                stageIndex + 1, _advConfig.Stages.Count, label);
+
+            if (eventEmitter is not null)
+                await eventEmitter.EmitAsync("adversarial_stage_start", agent: stageTag,
+                    payload: new { stage = stageIndex + 1, label, generator = stage.Generator, critic = stage.Critic });
+
+            // --- Initial generation ---
+
+            AgentStarting?.Invoke(generator.Name ?? stage.Generator);
+            agentFactory.OnAgentTurnStarting();
+            changeTracker?.BeginTurn(generator.Name ?? stage.Generator, turn);
+
+            var generatorContext = BuildGeneratorContext(
+                generatorInstructions, sharedHistory, task, revision: null);
+
+            var genResponse = await InvokeAgentAsync(generator, generatorContext, cancellationToken);
+            var artifact    = genResponse.Text ?? string.Empty;
+
+            var genMsg = MakeMessage(
+                $"{stageTag}:{generator.Name}",
+                artifact, turn++, ExtractUsage(genResponse), ExtractToolCalls(genResponse.Messages));
+            cumulativeTokens += genMsg.Usage?.TotalTokens ?? 0;
+            FireTokenBudgetWarning(genMsg);
+            yield return genMsg;
+
+            if (config.MaxTotalTokens is { } cap1 && cumulativeTokens > cap1)
+                throw new BudgetExceededException(cumulativeTokens, cap1);
+
+            await FlushChangeTrackerAsync(genMsg);
+
+            // --- Critique / revise loop ---
+
+            bool approved = false;
+
+            for (int round = 1; round <= _advConfig.Rounds; round++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                // Critic: fresh context — only its system instructions + artifact under review.
+                // No shared history, no generator reasoning. This is the context firewall.
+                AgentStarting?.Invoke(critic.Name ?? stage.Critic);
+                agentFactory.OnAgentTurnStarting();
+                changeTracker?.BeginTurn(critic.Name ?? stage.Critic, turn);
+
+                var criticContext = BuildCriticContext(criticInstructions, artifact, round, _advConfig.Rounds, _advConfig.PassKeyword);
+                var critiqueResponse = await InvokeAgentAsync(critic, criticContext, cancellationToken);
+                var critiqueText     = critiqueResponse.Text ?? string.Empty;
+
+                var critiqueMsg = MakeMessage(
+                    $"{stageTag}:{critic.Name}:Round{round}",
+                    critiqueText, turn++, ExtractUsage(critiqueResponse), ExtractToolCalls(critiqueResponse.Messages));
+                cumulativeTokens += critiqueMsg.Usage?.TotalTokens ?? 0;
+                FireTokenBudgetWarning(critiqueMsg);
+
+                logger.LogDebug(
+                    "[AdversarialOrchestrator] Stage {Index} round {Round}/{Max}: critic '{Critic}' responded ({Chars} chars).",
+                    stageIndex + 1, round, _advConfig.Rounds, stage.Critic, critiqueText.Length);
+
+                yield return critiqueMsg;
+
+                if (config.MaxTotalTokens is { } cap2 && cumulativeTokens > cap2)
+                    throw new BudgetExceededException(cumulativeTokens, cap2);
+
+                await FlushChangeTrackerAsync(critiqueMsg);
+
+                if (PassKeywordFound(critiqueText, _advConfig.PassKeyword))
+                {
+                    approved = true;
+                    logger.LogInformation(
+                        "[AdversarialOrchestrator] Stage {Index} '{Label}' passed at round {Round}/{Max}.",
+                        stageIndex + 1, label, round, _advConfig.Rounds);
+
+                    if (eventEmitter is not null)
+                        await eventEmitter.EmitAsync("adversarial_stage_pass", agent: stageTag,
+                            payload: new { stage = stageIndex + 1, label, round });
+                    break;
+                }
+
+                // Not approved — revise if rounds remain.
+                if (round < _advConfig.Rounds)
+                {
+                    AgentStarting?.Invoke(generator.Name ?? stage.Generator);
+                    agentFactory.OnAgentTurnStarting();
+                    changeTracker?.BeginTurn(generator.Name ?? stage.Generator, turn);
+
+                    var revisionContext = BuildGeneratorContext(
+                        generatorInstructions, sharedHistory, task, revision: (artifact, critiqueText));
+                    var revisionResponse = await InvokeAgentAsync(generator, revisionContext, cancellationToken);
+                    artifact = revisionResponse.Text ?? string.Empty;
+
+                    var revisionMsg = MakeMessage(
+                        $"{stageTag}:{generator.Name}:Revision{round}",
+                        artifact, turn++, ExtractUsage(revisionResponse), ExtractToolCalls(revisionResponse.Messages));
+                    cumulativeTokens += revisionMsg.Usage?.TotalTokens ?? 0;
+                    FireTokenBudgetWarning(revisionMsg);
+                    yield return revisionMsg;
+
+                    if (config.MaxTotalTokens is { } cap3 && cumulativeTokens > cap3)
+                        throw new BudgetExceededException(cumulativeTokens, cap3);
+
+                    await FlushChangeTrackerAsync(revisionMsg);
+                }
+            }
+
+            if (!approved)
+            {
+                logger.LogWarning(
+                    "[AdversarialOrchestrator] Stage {Index} '{Label}' exhausted {Max} rounds without approval — promoting anyway.",
+                    stageIndex + 1, label, _advConfig.Rounds);
+
+                if (eventEmitter is not null)
+                    await eventEmitter.EmitAsync("adversarial_stage_timeout", agent: stageTag,
+                        payload: new { stage = stageIndex + 1, label, rounds = _advConfig.Rounds });
+            }
+
+            // Promote the final artifact into shared history so subsequent generators see it.
+            sharedHistory.Add(new ChatMessage(ChatRole.Assistant, artifact)
+            {
+                AuthorName = generator.Name ?? stage.Generator
+            });
+        }
+
+        logger.LogInformation("[AdversarialOrchestrator] All {Count} stages complete.", _advConfig.Stages.Count);
+
+        if (eventEmitter is not null)
+            await eventEmitter.EmitAsync("adversarial_complete", agent: "[Adversarial]",
+                payload: new { stages = _advConfig.Stages.Count });
+    }
+
+    // Context builders
+
+    /// <summary>
+    /// Builds the generator's invocation context.
+    /// On the initial call <paramref name="revision"/> is null — the generator receives
+    /// system instructions + prior-stage shared history + the task.
+    /// On revision calls it additionally receives the previous artifact and the critique
+    /// as a user message so it knows exactly what to fix.
+    /// </summary>
+    private static List<ChatMessage> BuildGeneratorContext(
+        string? instructions,
+        List<ChatMessage> sharedHistory,
+        string task,
+        (string PrevArtifact, string Critique)? revision)
+    {
+        var context = new List<ChatMessage>();
+
+        if (!string.IsNullOrWhiteSpace(instructions))
+            context.Add(new ChatMessage(ChatRole.System, instructions));
+
+        context.AddRange(sharedHistory);
+        context.Add(new ChatMessage(ChatRole.User, task));
+
+        if (revision is var (prevArtifact, critique))
+        {
+            // Inject previous artifact as an assistant turn so the LLM knows what it produced.
+            context.Add(new ChatMessage(ChatRole.Assistant, prevArtifact));
+            context.Add(new ChatMessage(ChatRole.User,
+                $"The reviewer raised the following concerns:\n\n{critique}\n\n" +
+                "Please revise your response to address all of these points."));
+        }
+
+        return context;
+    }
+
+    /// <summary>
+    /// Builds the critic's invocation context — always fresh, always isolated.
+    /// The critic sees only its system instructions and the artifact to review.
+    /// It never sees shared history or generator reasoning.
+    /// </summary>
+    private static List<ChatMessage> BuildCriticContext(
+        string? instructions,
+        string artifact,
+        int round,
+        int totalRounds,
+        string passKeyword)
+    {
+        var context = new List<ChatMessage>();
+
+        if (!string.IsNullOrWhiteSpace(instructions))
+            context.Add(new ChatMessage(ChatRole.System, instructions));
+
+        var roundNote = totalRounds > 1
+            ? $" (review round {round} of {totalRounds})"
+            : string.Empty;
+
+        context.Add(new ChatMessage(ChatRole.User,
+            $"Review the following artifact{roundNote} and provide specific, actionable feedback.\n\n" +
+            $"If the artifact meets all requirements, respond with \"{passKeyword}\" on its own line " +
+            "and nothing else before it. Otherwise describe what must be improved — be specific.\n\n" +
+            $"ARTIFACT:\n\n{artifact}"));
+
+        return context;
+    }
+
+    private async Task<AgentResponse> InvokeAgentAsync(
+        AIAgent agent,
+        IEnumerable<ChatMessage> context,
+        CancellationToken cancellationToken)
+    {
+        return governanceKernel?.CircuitBreaker is { } cb
+            ? await cb.ExecuteAsync(() => agent.RunAsync(context, null, null, cancellationToken))
+            : await agent.RunAsync(context, null, null, cancellationToken);
+    }
+
+    private async Task FlushChangeTrackerAsync(AgentMessage msg)
+    {
+        if (changeTracker is null) return;
+        try
+        {
+            await changeTracker.FlushTurnAsync(msg.AgentName, msg.TurnIndex, CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "ChangeTracker flush failed for turn {Turn} ({Agent}).", msg.TurnIndex, msg.AgentName);
+        }
+    }
+
+    // Pass-keyword detection: the keyword must appear on its own line (case-insensitive).
+    private static bool PassKeywordFound(string text, string keyword) =>
+        text.Split('\n').Any(line =>
+            line.Trim().Equals(keyword, StringComparison.OrdinalIgnoreCase));
+
+    private void FireTokenBudgetWarning(AgentMessage msg)
+    {
+        var threshold = config.WarnTurnTokens;
+        if (threshold > 0 && msg.Usage?.InputTokens is { } inputToks && inputToks > threshold)
+            TokenBudgetWarning?.Invoke(msg.AgentName, inputToks, threshold);
+    }
+
+    private static AgentMessage MakeMessage(
+        string agentName,
+        string content,
+        int turnIndex,
+        TokenUsage? usage,
+        IReadOnlyList<ToolCallRecord>? toolCalls = null)
+        => new()
+        {
+            AgentName = agentName,
+            Content   = content,
+            Role      = "assistant",
+            TurnIndex = turnIndex,
+            Usage     = usage,
+            ToolCalls = toolCalls,
+        };
+
+    private static TokenUsage? ExtractUsage(AgentResponse response)
+    {
+        if (response.Usage is null) return null;
+
+        var inputTokens  = (int)(response.Usage.InputTokenCount  ?? 0L);
+        var outputTokens = (int)(response.Usage.OutputTokenCount ?? 0L);
+        if (inputTokens == 0 && outputTokens == 0) return null;
+
+        return new TokenUsage(inputTokens, outputTokens);
+    }
+
+    private static IReadOnlyList<ToolCallRecord>? ExtractToolCalls(IList<ChatMessage> messages)
+    {
+        var calls   = new List<(string CallId, string Name, string? ArgsSummary)>();
+        var results = new Dictionary<string, bool>(StringComparer.Ordinal);
+
+        try
+        {
+            foreach (var msg in messages)
+            {
+                foreach (var content in msg.Contents)
+                {
+                    if (content is FunctionCallContent fc)
+                        calls.Add((fc.CallId ?? fc.Name, fc.Name, ToolCallHelper.SummarizeArgs(fc.Arguments)));
+                    else if (content is FunctionResultContent fr)
+                    {
+                        var key  = fr.CallId ?? string.Empty;
+                        var text = fr.Result?.ToString() ?? string.Empty;
+                        var ok   = !text.StartsWith("[ERROR]",     StringComparison.Ordinal)
+                                && !text.StartsWith("[DENIED]",    StringComparison.Ordinal)
+                                && !text.StartsWith("[TIMEOUT]",   StringComparison.Ordinal)
+                                && !text.StartsWith("[NOT FOUND]", StringComparison.Ordinal)
+                                && !text.StartsWith("[EXIT ",      StringComparison.Ordinal);
+                        if (!string.IsNullOrEmpty(key)) results[key] = ok;
+                    }
+                }
+            }
+        }
+        catch (Exception) { /* best-effort */ }
+
+        if (calls.Count == 0) return null;
+
+        return calls
+            .Select(c => new ToolCallRecord(c.Name, c.ArgsSummary, results.TryGetValue(c.CallId, out var s) ? s : true))
+            .ToList();
+    }
+}


### PR DESCRIPTION
Introduces Selection.Type: "adversarial" — a new first-class orchestrator that pairs generator agents with critic agents in isolated context windows. Critics receive no shared history and no generator reasoning, producing genuinely independent review rather than inherited rubber-stamping.

New files:
- AdversarialConfig.cs — Stages, Rounds, PassKeyword config model
- AdversarialOrchestrator.cs — stacked generate→critique→revise loop with context firewall, TokenBudgetWarning, ChangeTracker, EventEmitter, and GovernanceKernel circuit-breaker integration
- InitTemplates.Adversarial.cs — fuseraft init --template adversarial

Updated:
- StrategyConfig.cs — AdversarialConfig? Adversarial property
- OrchestratorBuilder.cs — startup validation, mismatch warning, dispatch
- ValidateConfigCommand.cs — allowed type list, ValidateAdversarialSelection
- WorkflowDiagramGenerator.cs — RenderAdversarial Mermaid renderer
- InitTemplates.cs — "adversarial" dispatch case
- docs/strategies.md — full adversarial section, updated comparison table and Choosing a strategy guidance
- README.md — adversarial diagram in What you can build, feature count, init template example

## Summary

<!-- What does this PR do and why? One short paragraph is enough for most changes.
     For larger changes, a few bullet points work well. -->

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Plugin
- [ ] Config example
- [x] Documentation
- [x] Refactor / cleanup
- [ ] Other: <!-- describe -->

## Related issues

No related issue

## Changes

- Added new adversarial selection strategy.

## Testing

<!-- How did you verify this? Check all that apply. -->

- [ ] Added or updated unit tests
- [x] All tests pass locally (`./build.sh --target=Test`)
- [ ] Tested manually end-to-end
- [x] Documentation updated where relevant
- [ ] `config/examples/` updated if config schema changed

## Invariants

<!-- For changes to orchestration, strategies, or validators — confirm these hold. -->

- [x] Execution order unchanged (Selection → Validation → Failure handling → Termination → Iteration cap)
- [x] Any new file/shell/git tool is wrapped by `ChangeTracker`
- [x] Any new validator is deterministic, side-effect free, and idempotent
- [x] Physical history is not stripped or reordered outside of compaction

<!-- Not applicable to most PRs — uncheck or remove the section if so. -->

## Notes for reviewers

<!-- Anything that would help a reviewer understand context, trade-offs, or what to focus on. -->
