### PR TITLE
fix(sqlite): embed e_sqlite3 native lib in single-file publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
             --runtime ${{ matrix.rid }} \
             --self-contained true \
             -p:PublishSingleFile=true \
+            -p:IncludeNativeLibrariesForSelfExtract=true \
             -p:EnableCompressionInSingleFile=true \
             -p:DebugType=none \
             -p:DebugSymbols=false \

--- a/build.cake
+++ b/build.cake
@@ -242,8 +242,9 @@ Task("Publish")
             settings.Runtime       = runtime;
             settings.SelfContained = true;
             settings.MSBuildSettings
-                .WithProperty("PublishSingleFile",              "true")
-                .WithProperty("EnableCompressionInSingleFile",  "true");
+                .WithProperty("PublishSingleFile",                    "true")
+                .WithProperty("IncludeNativeLibrariesForSelfExtract", "true")
+                .WithProperty("EnableCompressionInSingleFile",        "true");
 
             Information($"Self-contained single-file publish for: {runtime}");
         }

--- a/src/Cli/Commands/SkillsCommand.cs
+++ b/src/Cli/Commands/SkillsCommand.cs
@@ -58,7 +58,18 @@ public sealed class SkillsAddCommand : AsyncCommand<SkillsAddSettings>
         await File.WriteAllTextAsync(destPath, content, cancellationToken);
 
         await using var index = new SkillIndex();
-        await index.IndexAsync(slug, destPath, content, cancellationToken);
+        try
+        {
+            await index.IndexAsync(slug, destPath, content, cancellationToken);
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("e_sqlite3") || ex.Message.Contains("SQLite"))
+        {
+            AnsiConsole.MarkupLine($"[red]✗ Skill index unavailable:[/] {Markup.Escape(ex.Message)}");
+            // The skill file was already written; report partial success so the user isn't blocked.
+            var verb2 = isUpdate ? "Updated" : "Added";
+            AnsiConsole.MarkupLine($"[green]✓[/] {verb2} [bold]{Markup.Escape(slug)}[/] → {Markup.Escape(destPath)} [dim](index skipped)[/]");
+            return 0;
+        }
 
         var verb = isUpdate ? "Updated" : "Added";
         AnsiConsole.MarkupLine($"[green]✓[/] {verb} [bold]{Markup.Escape(slug)}[/] → {Markup.Escape(destPath)}");
@@ -140,7 +151,15 @@ public sealed class SkillsRemoveCommand : AsyncCommand<SkillsRemoveSettings>
         Directory.Delete(destDir, recursive: true);
 
         await using var index = new SkillIndex();
-        await index.RemoveAsync(slug, cancellationToken);
+        try
+        {
+            await index.RemoveAsync(slug, cancellationToken);
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("e_sqlite3") || ex.Message.Contains("SQLite"))
+        {
+            // Skill directory already deleted; index cleanup is best-effort.
+            AnsiConsole.MarkupLine($"[yellow]⚠[/] Skill files removed but index update failed: {Markup.Escape(ex.Message)}");
+        }
 
         AnsiConsole.MarkupLine($"[green]✓[/] Removed [bold]{Markup.Escape(slug)}[/].");
         return 0;

--- a/src/FuseraftCli.csproj
+++ b/src/FuseraftCli.csproj
@@ -14,6 +14,12 @@
     <NoWarn>$(NoWarn);MAAI001</NoWarn>
   </PropertyGroup>
 
+  <!-- When publishing as a single-file binary, embed native libraries (e.g. e_sqlite3.so)
+       so they are self-extracted at startup rather than required as sibling files. -->
+  <PropertyGroup Condition="'$(PublishSingleFile)' == 'true'">
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Remove="FuseraftUpdate/**" />
   </ItemGroup>
@@ -56,6 +62,9 @@
 
     <!-- SQLite — skill index FTS5 -->
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.0" />
+    <!-- Bundle the native e_sqlite3 library inside the single-file executable so
+         it can be self-extracted at startup without a sibling .so file on disk. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Orchestration/SkillIndex.cs
+++ b/src/Orchestration/SkillIndex.cs
@@ -184,7 +184,19 @@ public sealed class SkillIndex(string? dbPath = null) : IAsyncDisposable
 
         Directory.CreateDirectory(Path.GetDirectoryName(_path)!);
 
-        _conn = new SqliteConnection($"Data Source={_path};Mode=ReadWriteCreate;Cache=Shared");
+        SqliteConnection conn;
+        try
+        {
+            conn = new SqliteConnection($"Data Source={_path};Mode=ReadWriteCreate;Cache=Shared");
+        }
+        catch (Exception ex) when (IsMissingNativeLib(ex))
+        {
+            throw new InvalidOperationException(
+                "SQLite native library (e_sqlite3) could not be loaded. " +
+                "Re-install fuseraft to get the updated binary with the embedded SQLite library.", ex);
+        }
+
+        _conn = conn;
         await _conn.OpenAsync(ct);
 
         // WAL mode for concurrent read access alongside writes
@@ -194,6 +206,21 @@ public sealed class SkillIndex(string? dbPath = null) : IAsyncDisposable
 
         await EnsureSchemaAsync(ct);
         return _conn;
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="ex"/> (or any inner exception) is a
+    /// <see cref="DllNotFoundException"/> for the SQLite native library, which happens
+    /// when the binary was installed without the embedded <c>e_sqlite3</c> native library.
+    /// </summary>
+    private static bool IsMissingNativeLib(Exception ex)
+    {
+        for (var e = ex; e is not null; e = e.InnerException)
+            if (e is DllNotFoundException dll &&
+                (dll.Message.Contains("e_sqlite3", StringComparison.OrdinalIgnoreCase) ||
+                 dll.Message.Contains("sqlite",    StringComparison.OrdinalIgnoreCase)))
+                return true;
+        return false;
     }
 
     private static string ExtractDescription(string skillContent)


### PR DESCRIPTION
## Summary

On Linux, dotnet's single-file bundler does not include native .so files by default, so e_sqlite3.so was left out of the published archive and missing at runtime after install.

- Add IncludeNativeLibrariesForSelfExtract=true to FuseraftCli.csproj (conditioned on PublishSingleFile=true) so the native library is embedded in the bundle and self-extracted at startup.
- Pin SQLitePCLRaw.bundle_e_sqlite3 explicitly to match the provider.
- Add the same flag to ci.yml publish step and build.cake for consistency.
- Catch DllNotFoundException (wrapped in TypeInitializationException) in SkillIndex.GetConnectionAsync and convert it to a clean InvalidOperationException with a helpful reinstall message.
- Handle that exception in SkillsAddCommand and SkillsRemoveCommand so old installs print a readable error instead of a crash dump.

<!-- What does this PR do and why? One short paragraph is enough for most changes.
     For larger changes, a few bullet points work well. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Plugin
- [ ] Config example
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Other: <!-- describe -->

## Related issues

<!-- Closes #, Fixes #, or "No related issue" -->

## Changes

<!-- List the meaningful changes. Skip obvious ones (e.g. "updated tests") unless the
     test approach is non-obvious and worth explaining. -->

-

## Testing

<!-- How did you verify this? Check all that apply. -->

- [ ] Added or updated unit tests
- [x] All tests pass locally (`./build.sh --target=Test`)
- [x] Tested manually end-to-end
- [ ] Documentation updated where relevant
- [ ] `config/examples/` updated if config schema changed

## Invariants

<!-- For changes to orchestration, strategies, or validators — confirm these hold. -->

- [ ] Execution order unchanged (Selection → Validation → Failure handling → Termination → Iteration cap)
- [ ] Any new file/shell/git tool is wrapped by `ChangeTracker`
- [ ] Any new validator is deterministic, side-effect free, and idempotent
- [ ] Physical history is not stripped or reordered outside of compaction

<!-- Not applicable to most PRs — uncheck or remove the section if so. -->

## Notes for reviewers

<!-- Anything that would help a reviewer understand context, trade-offs, or what to focus on. -->
