### PR TITLE
refactored: reorganize .fuseraft paths into clean subdirectories

### DIFF
--- a/config/examples/brownfield.yaml
+++ b/config/examples/brownfield.yaml
@@ -5,7 +5,7 @@
 ##
 ## Workflow:
 ##   1. Archaeologist surveys the codebase from EntryPoints, writes a discovery brief
-##      (.fuseraft/brief.brownfield.json) and a convention profile (.fuseraft/conventions.json).
+##      (.fuseraft/artifacts/brief.brownfield.json) and a convention profile (.fuseraft/artifacts/conventions.json).
 ##   2. OrchestratorBuilder seeds the change envelope from in_scope_files and injects
 ##      the convention profile into every agent's system prompt on subsequent runs.
 ##   3. Planner reads the discovery brief, narrows scope, and writes brief.json.
@@ -38,8 +38,8 @@ Orchestration:
   Brownfield:
     EntryPoints:
       - src/main.go        # Replace with your project's actual entry points
-    DiscoveryBriefPath: .fuseraft/brief.brownfield.json
-    ConventionProfilePath: .fuseraft/conventions.json
+    DiscoveryBriefPath: .fuseraft/artifacts/brief.brownfield.json
+    ConventionProfilePath: .fuseraft/artifacts/conventions.json
     SeedEnvelopeFromBrief: true   # merges in_scope_files → Security.ChangeEnvelope at startup
 
   ## Incremental test selection.
@@ -50,15 +50,15 @@ Orchestration:
     FullSuiteCommand: "go test ./..."
 
   EvidenceStore:
-    Path: .fuseraft/evidence.json
+    Path: .fuseraft/state/evidence.json
 
   ChangeTracking:
-    Path: .fuseraft/changes.json
+    Path: .fuseraft/state/changes.json
 
   Validation:
-    BriefPath: .fuseraft/brief.json
-    TestReportPath: .fuseraft/test-report.json
-    ChangeLogPath: .fuseraft/changes.json
+    BriefPath: .fuseraft/artifacts/brief.json
+    TestReportPath: .fuseraft/artifacts/test-report.json
+    ChangeLogPath: .fuseraft/state/changes.json
     TestAssertionPatterns:
       - "\\bt\\.Error\\b"
       - "\\bt\\.Fatal\\b"
@@ -79,19 +79,19 @@ Orchestration:
     - Name: ReconComplete
       Requires:
         - Type: FileExists
-          Path: .fuseraft/brief.brownfield.json
+          Path: .fuseraft/artifacts/brief.brownfield.json
         - Type: FileExists
-          Path: .fuseraft/conventions.json
+          Path: .fuseraft/artifacts/conventions.json
 
     - Name: BriefExists
       Requires:
         - Type: FileExists
-          Path: .fuseraft/brief.json
+          Path: .fuseraft/artifacts/brief.json
 
     - Name: ImplementationComplete
       Requires:
         - Type: FilesWritten
-          Source: .fuseraft/brief.json
+          Source: .fuseraft/artifacts/brief.json
           Field: files_to_change
         - Type: CommandSucceeded
           PatternField: verify_command
@@ -101,7 +101,7 @@ Orchestration:
     - Name: TestsValid
       Requires:
         - Type: FileExists
-          Path: .fuseraft/test-report.json
+          Path: .fuseraft/artifacts/test-report.json
         - Type: TestReport
           NoFailures: true
           HasAssertions: true
@@ -141,7 +141,7 @@ Orchestration:
         FOLLOW THESE STEPS IN ORDER:
 
         1. CHECK IF RECON ALREADY DONE:
-           Call read_file on .fuseraft/brief.brownfield.json.
+           Call read_file on .fuseraft/artifacts/brief.brownfield.json.
            If it exists and is non-empty, skip to step 7 immediately.
 
         2. SURVEY ENTRY POINTS:
@@ -172,7 +172,7 @@ Orchestration:
            Examine 3–5 representative files. Use sub_agent_explore for broad questions, sub_agent_locate for targeted symbol lookups.
 
         7. WRITE DISCOVERY BRIEF:
-           Call write_file → .fuseraft/brief.brownfield.json:
+           Call write_file → .fuseraft/artifacts/brief.brownfield.json:
            {
              "entry_points": ["<entry point paths>"],
              "in_scope_files": ["<relative path>", ...],
@@ -182,7 +182,7 @@ Orchestration:
            }
 
         8. WRITE CONVENTION PROFILE:
-           Call write_file → .fuseraft/conventions.json:
+           Call write_file → .fuseraft/artifacts/conventions.json:
            {
              "language": "<language>",
              "naming_patterns": ["<pattern>"],
@@ -224,7 +224,7 @@ Orchestration:
 
         FOLLOW THESE STEPS IN ORDER:
 
-        1. READ THE DISCOVERY BRIEF: Call read_file on .fuseraft/brief.brownfield.json.
+        1. READ THE DISCOVERY BRIEF: Call read_file on .fuseraft/artifacts/brief.brownfield.json.
            The in_scope_files and fragility_signals tell you what is safe to change.
 
         2. READ THE TASK: Extract the goal, constraints, and acceptance criteria.
@@ -243,7 +243,7 @@ Orchestration:
            - Constraints: include any fragility_signals for chosen files + coverage gaps
            Always include: "Test files contain real assertions that can fail."
 
-        6. WRITE BRIEF TO DISK: Call write_file → .fuseraft/brief.json:
+        6. WRITE BRIEF TO DISK: Call write_file → .fuseraft/artifacts/brief.json:
            {
              "goal": "<one sentence>",
              "files_to_change": ["src/billing/charge.go"],
@@ -273,16 +273,16 @@ Orchestration:
         You are an expert software developer working in a brownfield codebase.
 
         IMPORTANT: The change envelope is enforced — write_file and patch_file are blocked
-        for paths outside the files listed in .fuseraft/brief.json → files_to_change.
+        for paths outside the files listed in .fuseraft/artifacts/brief.json → files_to_change.
         If you need to touch an additional file, call handoff(route_keyword: "REPLAN REQUIRED")
         and explain which file needs to be added to scope.
 
         FOLLOW THESE STEPS IN ORDER:
 
-        1. READ THE BRIEF FROM DISK: Call read_file on .fuseraft/brief.json.
+        1. READ THE BRIEF FROM DISK: Call read_file on .fuseraft/artifacts/brief.json.
            If returning from a Reviewer rejection, the feedback field is your fix target.
 
-        2. READ FRAGILITY CONTEXT: Call read_file on .fuseraft/brief.brownfield.json
+        2. READ FRAGILITY CONTEXT: Call read_file on .fuseraft/artifacts/brief.brownfield.json
            and note any fragility_signals for the files you are about to change.
            Be conservative around fragile files: minimal diffs, no refactoring.
 
@@ -327,7 +327,7 @@ Orchestration:
 
         FOLLOW THESE STEPS IN ORDER:
 
-        1. READ THE BRIEF FROM DISK: Call read_file on .fuseraft/brief.json.
+        1. READ THE BRIEF FROM DISK: Call read_file on .fuseraft/artifacts/brief.json.
         2. CHECK THE CHANGE LOG: Call changes_read_latest.
         3. AUDIT TEST CODE: A test file is only valid if it contains assertion logic
            that can actually FAIL. Print-only files are not tests — BUGS FOUND immediately.
@@ -339,7 +339,7 @@ Orchestration:
 
         5. TEST EACH ACCEPTANCE CRITERION with shell_run. Record PASS or FAIL.
 
-        6a. ALL PASS: Write test report to .fuseraft/test-report.json:
+        6a. ALL PASS: Write test report to .fuseraft/artifacts/test-report.json:
               {
                 "results": [
                   {
@@ -356,7 +356,7 @@ Orchestration:
         6b. ANY FAIL: Call handoff(route_keyword: "BUGS FOUND") and list every failure.
 
         RULES:
-        - Never call HANDOFF TO REVIEWER before writing .fuseraft/test-report.json.
+        - Never call HANDOFF TO REVIEWER before writing .fuseraft/artifacts/test-report.json.
         - Never fabricate shell output.
         - A PASS result with an empty or missing command field is treated as fabricated and will block handoff.
       Model:
@@ -386,7 +386,7 @@ Orchestration:
            Flag any deviation from naming, error handling, or forbidden patterns.
         4. AUDIT TESTS: Can each test actually fail if the feature is broken?
         5. SPOT-CHECK: Run the most critical acceptance criterion with shell_run.
-        6. READ THE TEST REPORT: Call read_file on .fuseraft/test-report.json.
+        6. READ THE TEST REPORT: Call read_file on .fuseraft/artifacts/test-report.json.
 
         7. EMIT A STRUCTURED VERDICT inside a ```json code fence:
 
@@ -509,7 +509,7 @@ Orchestration:
           - Reviewer
 
   Chatroom:
-    Path: .fuseraft/chatroom.jsonl
+    Path: .fuseraft/comms/chatroom.jsonl
 
   Events:
     Path: .fuseraft/events.jsonl

--- a/config/examples/dev-team-structured.yaml
+++ b/config/examples/dev-team-structured.yaml
@@ -23,15 +23,15 @@ Orchestration:
       ApiKeyEnvVar: XAI_API_KEY
 
   EvidenceStore:
-    Path: .fuseraft/evidence.json
+    Path: .fuseraft/state/evidence.json
 
   ChangeTracking:
-    Path: .fuseraft/changes.json
+    Path: .fuseraft/state/changes.json
 
   Validation:
-    BriefPath: .fuseraft/brief.json
-    TestReportPath: .fuseraft/test-report.json
-    ChangeLogPath: .fuseraft/changes.json
+    BriefPath: .fuseraft/artifacts/brief.json
+    TestReportPath: .fuseraft/artifacts/test-report.json
+    ChangeLogPath: .fuseraft/state/changes.json
     TestAssertionPatterns:
       - "tester::assert"
       - "if .+ throw"
@@ -42,12 +42,12 @@ Orchestration:
     - Name: BriefExists
       Requires:
         - Type: FileExists
-          Path: .fuseraft/brief.json
+          Path: .fuseraft/artifacts/brief.json
 
     - Name: ImplementationComplete
       Requires:
         - Type: FilesWritten
-          Source: .fuseraft/brief.json
+          Source: .fuseraft/artifacts/brief.json
           Field: files_to_change
         - Type: CommandSucceeded
           PatternField: verify_command
@@ -56,7 +56,7 @@ Orchestration:
     - Name: TestsValid
       Requires:
         - Type: FileExists
-          Path: .fuseraft/test-report.json
+          Path: .fuseraft/artifacts/test-report.json
         - Type: TestReport
           NoFailures: true
           HasAssertions: true
@@ -107,7 +107,7 @@ Orchestration:
            - Constraints: anything to avoid or preserve
            Always include: "Test files contain real assertions that can fail."
 
-        5. WRITE BRIEF TO DISK: Call write_file → .fuseraft/brief.json:
+        5. WRITE BRIEF TO DISK: Call write_file → .fuseraft/artifacts/brief.json:
              {
                "goal": "<one sentence>",
                "files_to_change": ["src/a.go", "src/b.go"],
@@ -137,7 +137,7 @@ Orchestration:
 
         FOLLOW THESE STEPS IN ORDER:
 
-        1. READ THE BRIEF FROM DISK: Call read_file on .fuseraft/brief.json.
+        1. READ THE BRIEF FROM DISK: Call read_file on .fuseraft/artifacts/brief.json.
            If returning from a Reviewer rejection, the feedback field is your fix target.
 
         2. IMPLEMENT: Use write_file for every file in files_to_change. Never output a diff.
@@ -176,14 +176,14 @@ Orchestration:
 
         FOLLOW THESE STEPS IN ORDER:
 
-        1. READ THE BRIEF FROM DISK: Call read_file on .fuseraft/brief.json.
+        1. READ THE BRIEF FROM DISK: Call read_file on .fuseraft/artifacts/brief.json.
         2. CHECK THE CHANGE LOG: Call changes_read_latest.
         3. AUDIT TEST CODE: A test file is only valid if it contains assertion logic
            that can actually FAIL. Print-only files are not tests — BUGS FOUND immediately.
         4. RUN TESTS: Paste exact stdout/stderr. Any failure = FAIL.
         5. TEST EACH ACCEPTANCE CRITERION with shell_run. Record PASS or FAIL.
 
-        6a. ALL PASS: Write test report to .fuseraft/test-report.json:
+        6a. ALL PASS: Write test report to .fuseraft/artifacts/test-report.json:
               {
                 "results": [
                   {
@@ -200,7 +200,7 @@ Orchestration:
         6b. ANY FAIL: Call handoff(route_keyword: "BUGS FOUND") and list every failure.
 
         RULES:
-        - Never call HANDOFF TO REVIEWER before writing .fuseraft/test-report.json.
+        - Never call HANDOFF TO REVIEWER before writing .fuseraft/artifacts/test-report.json.
         - Never fabricate shell output.
         - A PASS result with an empty or missing command field is treated as fabricated and will block handoff.
       Model:
@@ -228,7 +228,7 @@ Orchestration:
         3. REVIEW: Correctness, consistency, error handling, edge cases, security.
         3b. AUDIT TESTS: Can each test actually fail if the feature is broken?
         4. SPOT-CHECK: Run the most critical acceptance criterion with shell_run.
-        5. READ THE TEST REPORT: Call read_file on .fuseraft/test-report.json.
+        5. READ THE TEST REPORT: Call read_file on .fuseraft/artifacts/test-report.json.
 
         6. EMIT A STRUCTURED VERDICT inside a ```json code fence:
 
@@ -342,7 +342,7 @@ Orchestration:
           - Reviewer
 
   Chatroom:
-    Path: .fuseraft/chatroom.jsonl
+    Path: .fuseraft/comms/chatroom.jsonl
 
   Events:
     Path: .fuseraft/events.jsonl

--- a/config/examples/devops-team.json
+++ b/config/examples/devops-team.json
@@ -4,18 +4,18 @@
     "Description": "Three-agent DevOps pipeline: Architect designs and writes a plan, Engineer implements and validates with real shell commands, Operator executes the deployment. State machine routing with evidence contracts gates each handoff.",
 
     "EvidenceStore": {
-      "Path": ".fuseraft/evidence.json"
+      "Path": ".fuseraft/state/evidence.json"
     },
 
     "ChangeTracking": {
-      "Path": ".fuseraft/changes.json"
+      "Path": ".fuseraft/state/changes.json"
     },
 
     "Contracts": [
       {
         "Name": "PlanExists",
         "Requires": [
-          { "Type": "FileExists", "Path": ".fuseraft/brief.json" }
+          { "Type": "FileExists", "Path": ".fuseraft/artifacts/brief.json" }
         ]
       },
       {
@@ -42,7 +42,7 @@
       {
         "Name": "Architect",
         "Description": "Senior architect who analyses requirements and writes a concrete implementation plan to disk.",
-        "Instructions": "You are a senior software architect.\n\nFOLLOW THESE STEPS IN ORDER:\n\n1. EXPLORE: Use search_files and read_file to understand the existing codebase structure before planning.\n\n2. PRODUCE A PLAN: Write a detailed, step-by-step implementation plan: which files to create or modify, what commands to run, what dependencies are needed. Be specific — name exact file paths and commands.\n\n3. WRITE PLAN TO DISK: Call write_file to save .fuseraft/brief.json:\n     {\n       \"goal\": \"<one sentence>\",\n       \"steps\": [\"<step 1>\", \"<step 2>\"],\n       \"files_to_change\": [\"<path>\"],\n       \"rollback\": [\"<rollback step>\"]\n     }\n\n4. HAND OFF: Call handoff(route_keyword: \"HANDOFF TO ENGINEER\").",
+        "Instructions": "You are a senior software architect.\n\nFOLLOW THESE STEPS IN ORDER:\n\n1. EXPLORE: Use search_files and read_file to understand the existing codebase structure before planning.\n\n2. PRODUCE A PLAN: Write a detailed, step-by-step implementation plan: which files to create or modify, what commands to run, what dependencies are needed. Be specific — name exact file paths and commands.\n\n3. WRITE PLAN TO DISK: Call write_file to save .fuseraft/artifacts/brief.json:\n     {\n       \"goal\": \"<one sentence>\",\n       \"steps\": [\"<step 1>\", \"<step 2>\"],\n       \"files_to_change\": [\"<path>\"],\n       \"rollback\": [\"<rollback step>\"]\n     }\n\n4. HAND OFF: Call handoff(route_keyword: \"HANDOFF TO ENGINEER\").",
         "Model": {
           "ModelId": "grok-4-1-fast-reasoning",
           "Endpoint": "https://api.x.ai/v1",
@@ -55,7 +55,7 @@
       {
         "Name": "Engineer",
         "Description": "Full-stack engineer who executes the plan using tools — never describes changes without making them.",
-        "Instructions": "You are a full-stack engineer executing the Architect's plan.\n\nFOLLOW THESE STEPS IN ORDER:\n\n1. READ: Call read_file on .fuseraft/brief.json and any files you need to modify.\n\n2. IMPLEMENT: Use write_file with complete file content. Never output a diff or describe what you would write — write the full file.\n\n3. VERIFY WRITES: Use read_file immediately after writing to confirm content is correct.\n\n4. RUN: Use shell_run to install dependencies, build, lint, or test. Include exact stdout/stderr output. At least one passing shell_run is required before handoff — this is enforced by contract.\n\n5. VERSION CONTROL: Use git_add and git_commit to commit your changes.\n\n6. HAND OFF: Call handoff(route_keyword: \"HANDOFF TO OPERATOR\") with a list of changed files and actual command output.\n   If the plan needs rethinking, call handoff(route_keyword: \"REPLAN REQUIRED\").\n\nRULES:\n- Never describe a change without making it with write_file.\n- Never claim a command succeeded without showing its real output.\n- If any step fails, fix it before proceeding.",
+        "Instructions": "You are a full-stack engineer executing the Architect's plan.\n\nFOLLOW THESE STEPS IN ORDER:\n\n1. READ: Call read_file on .fuseraft/artifacts/brief.json and any files you need to modify.\n\n2. IMPLEMENT: Use write_file with complete file content. Never output a diff or describe what you would write — write the full file.\n\n3. VERIFY WRITES: Use read_file immediately after writing to confirm content is correct.\n\n4. RUN: Use shell_run to install dependencies, build, lint, or test. Include exact stdout/stderr output. At least one passing shell_run is required before handoff — this is enforced by contract.\n\n5. VERSION CONTROL: Use git_add and git_commit to commit your changes.\n\n6. HAND OFF: Call handoff(route_keyword: \"HANDOFF TO OPERATOR\") with a list of changed files and actual command output.\n   If the plan needs rethinking, call handoff(route_keyword: \"REPLAN REQUIRED\").\n\nRULES:\n- Never describe a change without making it with write_file.\n- Never claim a command succeeded without showing its real output.\n- If any step fails, fix it before proceeding.",
         "Model": {
           "ModelId": "grok-4-1-fast-non-reasoning",
           "Endpoint": "https://api.x.ai/v1",
@@ -68,7 +68,7 @@
       {
         "Name": "Operator",
         "Description": "Site reliability engineer who executes the deployment and verifies success.",
-        "Instructions": "You are a site reliability engineer.\n\nFOLLOW THESE STEPS IN ORDER:\n\n1. READ THE PLAN: Call read_file on .fuseraft/brief.json.\n\n2. CHECK THE CHANGE LOG: Call changes_read_latest to verify what the Engineer built.\n\n3. EXECUTE: Run the deployment steps from the plan using shell_run. Paste exact stdout/stderr.\n\n4. VERIFY: Run smoke tests to confirm the deployment succeeded.\n\n5. REPORT:\n   - All checks pass → call handoff(route_keyword: \"DEPLOYMENT_COMPLETE\") followed by a brief changelog entry.\n   - Something failed → call handoff(route_keyword: \"DEPLOYMENT_FAILED\") and describe exactly what went wrong.\n\nRULES:\n- Never claim success without showing real shell_run output.\n- If any step fails, stop and report rather than continuing.",
+        "Instructions": "You are a site reliability engineer.\n\nFOLLOW THESE STEPS IN ORDER:\n\n1. READ THE PLAN: Call read_file on .fuseraft/artifacts/brief.json.\n\n2. CHECK THE CHANGE LOG: Call changes_read_latest to verify what the Engineer built.\n\n3. EXECUTE: Run the deployment steps from the plan using shell_run. Paste exact stdout/stderr.\n\n4. VERIFY: Run smoke tests to confirm the deployment succeeded.\n\n5. REPORT:\n   - All checks pass → call handoff(route_keyword: \"DEPLOYMENT_COMPLETE\") followed by a brief changelog entry.\n   - Something failed → call handoff(route_keyword: \"DEPLOYMENT_FAILED\") and describe exactly what went wrong.\n\nRULES:\n- Never claim success without showing real shell_run output.\n- If any step fails, stop and report rather than continuing.",
         "Model": {
           "ModelId": "grok-4-1-fast-reasoning",
           "Endpoint": "https://api.x.ai/v1",

--- a/config/examples/open-webui.yaml
+++ b/config/examples/open-webui.yaml
@@ -14,15 +14,15 @@ Orchestration:
       ApiKeyEnvVar: OPENWEBUI_API_KEY
 
   EvidenceStore:
-    Path: .fuseraft/evidence.json
+    Path: .fuseraft/state/evidence.json
 
   ChangeTracking:
-    Path: .fuseraft/changes.json
+    Path: .fuseraft/state/changes.json
 
   Validation:
-    BriefPath: .fuseraft/brief.json
-    TestReportPath: .fuseraft/test-report.json
-    ChangeLogPath: .fuseraft/changes.json
+    BriefPath: .fuseraft/artifacts/brief.json
+    TestReportPath: .fuseraft/artifacts/test-report.json
+    ChangeLogPath: .fuseraft/state/changes.json
     TestAssertionPatterns:
       - "tester::assert"
       - "if .+ throw"
@@ -33,12 +33,12 @@ Orchestration:
     - Name: BriefExists
       Requires:
         - Type: FileExists
-          Path: .fuseraft/brief.json
+          Path: .fuseraft/artifacts/brief.json
 
     - Name: ImplementationComplete
       Requires:
         - Type: FilesWritten
-          Source: .fuseraft/brief.json
+          Source: .fuseraft/artifacts/brief.json
           Field: files_to_change
         - Type: CommandSucceeded
           Pattern: "build|compile|run|go test|npm test|cargo test"
@@ -46,7 +46,7 @@ Orchestration:
     - Name: TestsValid
       Requires:
         - Type: FileExists
-          Path: .fuseraft/test-report.json
+          Path: .fuseraft/artifacts/test-report.json
         - Type: TestReport
           NoFailures: true
           HasAssertions: true
@@ -97,7 +97,7 @@ Orchestration:
            ALWAYS include this as an acceptance criterion when tests are involved:
            'Test files contain real assertions that can fail (if/throw, tester::assert, or equivalent) — not just print statements.'
 
-        5. WRITE BRIEF TO DISK: Call write_file to save .fuseraft/brief.json.
+        5. WRITE BRIEF TO DISK: Call write_file to save .fuseraft/artifacts/brief.json.
            Schema:
              {
                "goal": "<one sentence>",
@@ -133,7 +133,7 @@ Orchestration:
 
         FOLLOW THESE STEPS IN ORDER:
 
-        1. READ THE BRIEF FROM DISK: Call read_file on .fuseraft/brief.json to get the canonical brief. Note the goal, files_to_change, acceptance_criteria, and constraints. If the Tester has reported BUGS FOUND, that report is your specific fix target.
+        1. READ THE BRIEF FROM DISK: Call read_file on .fuseraft/artifacts/brief.json to get the canonical brief. Note the goal, files_to_change, acceptance_criteria, and constraints. If the Tester has reported BUGS FOUND, that report is your specific fix target.
 
         2. IMPLEMENT: Use write_file to write the complete new or modified file content for every path in files_to_change. Do not describe what you would write — write it. Never output a diff.
 
@@ -177,7 +177,7 @@ Orchestration:
 
         FOLLOW THESE STEPS IN ORDER:
 
-        1. READ THE BRIEF FROM DISK: Call read_file on .fuseraft/brief.json to get the acceptance criteria.
+        1. READ THE BRIEF FROM DISK: Call read_file on .fuseraft/artifacts/brief.json to get the acceptance criteria.
 
         2. CHECK THE CHANGE LOG: Call changes_read_latest to see exactly what the Developer wrote and ran this turn.
 
@@ -189,7 +189,7 @@ Orchestration:
 
         6. TEST EACH ACCEPTANCE CRITERION with shell_run. Record PASS or FAIL for each.
 
-        7a. IF ALL CRITERIA PASS: Write the test report to .fuseraft/test-report.json:
+        7a. IF ALL CRITERIA PASS: Write the test report to .fuseraft/artifacts/test-report.json:
               {
                 "results": [
                   {
@@ -207,7 +207,7 @@ Orchestration:
 
         RULES:
         - NEVER call HANDOFF TO REVIEWER unless every criterion has real shell_run output showing PASS.
-        - NEVER call HANDOFF TO REVIEWER before writing .fuseraft/test-report.json to disk.
+        - NEVER call HANDOFF TO REVIEWER before writing .fuseraft/artifacts/test-report.json to disk.
         - A PASS result with an empty or missing command field is treated as fabricated and will block handoff.
       Model:
         ModelId: owui-default
@@ -242,8 +242,8 @@ Orchestration:
 
         5. SPOT-CHECK WITH SHELL: Run the most critical acceptance criterion yourself using shell_run. You must produce at least one successful shell_run before signalling APPROVED.
 
-        6. READ THE TEST REPORT FROM DISK: Call read_file on .fuseraft/test-report.json.
-           Confirm a PASS entry with a non-empty command exists for every criterion from .fuseraft/brief.json.
+        6. READ THE TEST REPORT FROM DISK: Call read_file on .fuseraft/artifacts/test-report.json.
+           Confirm a PASS entry with a non-empty command exists for every criterion from .fuseraft/artifacts/brief.json.
 
         7. EMIT A STRUCTURED JUDGEMENT inside a ```json code fence:
 
@@ -356,7 +356,7 @@ Orchestration:
           - Reviewer
 
   Chatroom:
-    Path: .fuseraft/chatroom.jsonl
+    Path: .fuseraft/comms/chatroom.jsonl
 
   Events:
     Path: .fuseraft/events.jsonl

--- a/config/examples/orchestration.yaml
+++ b/config/examples/orchestration.yaml
@@ -22,15 +22,15 @@ Orchestration:
       ApiKeyEnvVar: XAI_API_KEY
 
   EvidenceStore:
-    Path: .fuseraft/evidence.json
+    Path: .fuseraft/state/evidence.json
 
   ChangeTracking:
-    Path: .fuseraft/changes.json
+    Path: .fuseraft/state/changes.json
 
   Validation:
-    BriefPath: .fuseraft/brief.json
-    TestReportPath: .fuseraft/test-report.json
-    ChangeLogPath: .fuseraft/changes.json
+    BriefPath: .fuseraft/artifacts/brief.json
+    TestReportPath: .fuseraft/artifacts/test-report.json
+    ChangeLogPath: .fuseraft/state/changes.json
     TestAssertionPatterns:
       - "tester::assert"
       - "if .+ throw"
@@ -41,12 +41,12 @@ Orchestration:
     - Name: BriefExists
       Requires:
         - Type: FileExists
-          Path: .fuseraft/brief.json
+          Path: .fuseraft/artifacts/brief.json
 
     - Name: ImplementationComplete
       Requires:
         - Type: FilesWritten
-          Source: .fuseraft/brief.json
+          Source: .fuseraft/artifacts/brief.json
           Field: files_to_change
         - Type: CommandSucceeded
           # Read the verify command from the Planner's brief so this works for any
@@ -59,7 +59,7 @@ Orchestration:
     - Name: TestsValid
       Requires:
         - Type: FileExists
-          Path: .fuseraft/test-report.json
+          Path: .fuseraft/artifacts/test-report.json
         - Type: TestReport
           NoFailures: true
           HasAssertions: true
@@ -104,7 +104,7 @@ Orchestration:
            - Acceptance criteria: bullet list of specific, testable conditions
            - Constraints: anything to avoid or preserve
 
-        4. WRITE BRIEF TO DISK: Call write_file to save .fuseraft/brief.json.
+        4. WRITE BRIEF TO DISK: Call write_file to save .fuseraft/artifacts/brief.json.
            Schema:
              {
                "goal": "<one sentence>",
@@ -131,7 +131,7 @@ Orchestration:
 
         FOLLOW THESE STEPS IN ORDER:
 
-        1. READ THE BRIEF FROM DISK: Call read_file on .fuseraft/brief.json.
+        1. READ THE BRIEF FROM DISK: Call read_file on .fuseraft/artifacts/brief.json.
         2. IMPLEMENT: Use write_file to write the complete new or modified file content.
            Implement every path listed in files_to_change.
         3. BUILD/RUN: Use shell_run to build and confirm it works. Include exact output.
@@ -157,11 +157,11 @@ Orchestration:
 
         FOLLOW THESE STEPS IN ORDER:
 
-        1. READ THE BRIEF: Call read_file on .fuseraft/brief.json.
+        1. READ THE BRIEF: Call read_file on .fuseraft/artifacts/brief.json.
         2. CHECK THE CHANGE LOG: Call changes_read_latest to verify what the Developer wrote.
         3. RUN TESTS: Execute the project's test suite with shell_run. Paste exact output.
         4. EVALUATE: Map each acceptance criterion to PASS or FAIL.
-        5. WRITE REPORT: Save results to .fuseraft/test-report.json:
+        5. WRITE REPORT: Save results to .fuseraft/artifacts/test-report.json:
              {
                "results": [
                  {
@@ -194,12 +194,12 @@ Orchestration:
 
         FOLLOW THESE STEPS IN ORDER:
 
-        1. READ THE BRIEF: Call read_file on .fuseraft/brief.json.
+        1. READ THE BRIEF: Call read_file on .fuseraft/artifacts/brief.json.
         2. READ THE CHANGE LOG: Call changes_read to see what was actually done this session.
         3. READ THE CODE: Use read_file to inspect the changed files.
         4. REVIEW: Check code quality, correctness, and adherence to the brief.
         5. SPOT-CHECK: Run at least one acceptance criterion yourself with shell_run.
-        6. READ THE TEST REPORT: Call read_file on .fuseraft/test-report.json.
+        6. READ THE TEST REPORT: Call read_file on .fuseraft/artifacts/test-report.json.
         7. DECIDE:
            - All criteria verified → call handoff(route_keyword: "APPROVED").
            - Code or tests need fixing → call handoff(route_keyword: "REVISION REQUIRED")

--- a/config/examples/research-team.json
+++ b/config/examples/research-team.json
@@ -4,11 +4,11 @@
     "Description": "Two-agent research pipeline: Researcher fetches data and writes structured findings to disk; Writer synthesises a polished report. State machine routing with a ResearchComplete contract ensures the Writer cannot start before findings exist on disk.",
 
     "EvidenceStore": {
-      "Path": ".fuseraft/evidence.json"
+      "Path": ".fuseraft/state/evidence.json"
     },
 
     "ChangeTracking": {
-      "Path": ".fuseraft/changes.json"
+      "Path": ".fuseraft/state/changes.json"
     },
 
     "Contracts": [

--- a/config/orchestration.yaml
+++ b/config/orchestration.yaml
@@ -16,15 +16,15 @@ Orchestration:
       ApiKeyEnvVar: XAI_API_KEY
 
   EvidenceStore:
-    Path: .fuseraft/evidence.json
+    Path: .fuseraft/state/evidence.json
 
   ChangeTracking:
-    Path: .fuseraft/changes.json
+    Path: .fuseraft/state/changes.json
 
   Validation:
-    BriefPath: .fuseraft/brief.json
-    TestReportPath: .fuseraft/test-report.json
-    ChangeLogPath: .fuseraft/changes.json
+    BriefPath: .fuseraft/artifacts/brief.json
+    TestReportPath: .fuseraft/artifacts/test-report.json
+    ChangeLogPath: .fuseraft/state/changes.json
     TestAssertionPatterns:
       - "tester::assert"
       - "if .+ throw"
@@ -35,12 +35,12 @@ Orchestration:
     - Name: BriefExists
       Requires:
         - Type: FileExists
-          Path: .fuseraft/brief.json
+          Path: .fuseraft/artifacts/brief.json
 
     - Name: ImplementationComplete
       Requires:
         - Type: FilesWritten
-          Source: .fuseraft/brief.json
+          Source: .fuseraft/artifacts/brief.json
           Field: files_to_change
         - Type: CommandSucceeded
           Pattern: "build|compile|test|check"
@@ -48,7 +48,7 @@ Orchestration:
     - Name: TestsValid
       Requires:
         - Type: FileExists
-          Path: .fuseraft/test-report.json
+          Path: .fuseraft/artifacts/test-report.json
         - Type: TestReport
           NoFailures: true
           HasAssertions: true
@@ -101,7 +101,7 @@ Orchestration:
            ALWAYS include this as an acceptance criterion when tests are involved: 'Test files contain real assertions that can fail (if/throw, tester::assert, or equivalent) — not just print statements.'
 
         5. WRITE BRIEF TO DISK: Immediately after writing the brief above, call write_file to save it as structured JSON:
-           - Path: .fuseraft/brief.json
+           - Path: .fuseraft/artifacts/brief.json
            - Content must match this exact schema:
              {
                "goal": "<one sentence>",
@@ -136,7 +136,7 @@ Orchestration:
 
         FOLLOW THESE STEPS IN ORDER:
 
-        1. READ THE BRIEF FROM DISK: Call read_file on .fuseraft/brief.json to get the canonical brief. Do not rely solely on the chat context — the file is the authoritative source that survives compaction. Note the goal, files_to_change, acceptance_criteria, and constraints. If the Tester has reported BUGS FOUND, that report is your specific fix target.
+        1. READ THE BRIEF FROM DISK: Call read_file on .fuseraft/artifacts/brief.json to get the canonical brief. Do not rely solely on the chat context — the file is the authoritative source that survives compaction. Note the goal, files_to_change, acceptance_criteria, and constraints. If the Tester has reported BUGS FOUND, that report is your specific fix target.
 
         2. IMPLEMENT: Use write_file to write the complete new or modified file content. Do not describe what you would write — write it. Never output a diff.
 
@@ -179,7 +179,7 @@ Orchestration:
 
         FOLLOW THESE STEPS IN ORDER:
 
-        1. READ THE BRIEF FROM DISK: Call read_file on .fuseraft/brief.json to get the acceptance criteria. The acceptance_criteria array is your test checklist — every item must pass.
+        1. READ THE BRIEF FROM DISK: Call read_file on .fuseraft/artifacts/brief.json to get the acceptance criteria. The acceptance_criteria array is your test checklist — every item must pass.
 
         1b. CHECK THE CHANGE LOG: Call changes_read_latest to see exactly what the Developer wrote and ran this turn. Cross-reference with files_to_change in the brief — if an expected file is missing from the change log, that is grounds for BUGS FOUND.
 
@@ -195,7 +195,7 @@ Orchestration:
            - Record PASS or FAIL for each criterion with the exact shell_run output — not a summary, the raw output.
 
         5a. IF ALL CRITERIA PASS: First write the test report to disk using write_file:
-           - Path: .fuseraft/test-report.json
+           - Path: .fuseraft/artifacts/test-report.json
            - Schema:
              {
                "results": [
@@ -216,7 +216,7 @@ Orchestration:
         RULES:
         - NEVER write output for a shell command you did not call with shell_run.
         - NEVER call handoff(route_keyword: "HANDOFF TO REVIEWER") unless every criterion has a real shell_run output showing PASS.
-        - NEVER call handoff(route_keyword: "HANDOFF TO REVIEWER") before writing .fuseraft/test-report.json to disk.
+        - NEVER call handoff(route_keyword: "HANDOFF TO REVIEWER") before writing .fuseraft/artifacts/test-report.json to disk.
       Model:
         ModelId: reasoning
         MaxTokens: 16384
@@ -247,8 +247,8 @@ Orchestration:
 
         4. SPOT-CHECK WITH SHELL: Run the most critical acceptance criterion yourself using shell_run. You must produce at least one successful shell_run before calling APPROVED.
 
-        5. READ THE TEST REPORT FROM DISK: Call read_file on .fuseraft/test-report.json.
-           a. Confirm the report has a PASS entry with a non-empty command for every criterion from .fuseraft/brief.json.
+        5. READ THE TEST REPORT FROM DISK: Call read_file on .fuseraft/artifacts/test-report.json.
+           a. Confirm the report has a PASS entry with a non-empty command for every criterion from .fuseraft/artifacts/brief.json.
            b. Check that shell output in the report is consistent with the code you read and your own spot-check.
 
         6. EMIT A STRUCTURED JUDGEMENT: Before writing your decision keyword, output a JSON block with a per-criterion verdict. Use exactly this format inside a ```json code fence:

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -26,7 +26,7 @@ fuseraft run [task] [options]
 | `--verbose` | off | Enable debug logging, including token counts per turn. |
 | `--tools` | off | Show tool calls made by each agent inline in the turn panel. |
 | `--no-banner` | off | Skip the ASCII banner. Useful for CI or piped output. |
-| `--ci` | off | CI mode. After the session ends, reads `.fuseraft/test-report.json` and exits with code `2` if any criterion has `status: FAIL`. Exits `0` if the report is absent or all criteria pass. |
+| `--ci` | off | CI mode. After the session ends, reads `.fuseraft/artifacts/test-report.json` and exits with code `2` if any criterion has `status: FAIL`. Exits `0` if the report is absent or all criteria pass. |
 | `--devui` | off | Start a local web server and print a URL for real-time session visualization. See [DevUI](#devui) below. |
 | `--work-dir <path>` | — | Set the working directory for the session. Priority: flag > `Security.FileSystemSandboxPath` in the config > current directory. |
 | `--context-file <path>` | — | Attach a file as context. Its content is appended to the task. PDF, DOCX, PPTX, and XLSX files are extracted to plain text automatically; other files are read as UTF-8. Repeatable — specify once per file. Ignored when resuming. |
@@ -641,10 +641,10 @@ When a session has stalled — the agent keeps making the same mistake, misunder
 
 The REPL automatically maintains a persistent memory store at `~/.fuseraft/memory/repl/`. Each entry is identified by a UUID and stored as `memory_{guid}.md`. Memories are **scoped to the working directory** where they were created:
 
-- If the current directory contains a `.fuseraft/` folder, the REPL loads only memories whose GUIDs are listed in `.fuseraft/memory_refs.json`. Directories with a `.fuseraft/` folder but no refs file start with an empty memory set (no cross-project bleed).
+- If the current directory contains a `.fuseraft/` folder, the REPL loads only memories whose GUIDs are listed in `.fuseraft/memory/memory_refs.json`. Directories with a `.fuseraft/` folder but no refs file start with an empty memory set (no cross-project bleed).
 - Directories without a `.fuseraft/` folder fall back to loading all global memories (legacy behaviour, useful outside of a project context).
 
-When a memory is saved, the REPL writes the entry to the global store and registers its GUID in `.fuseraft/memory_refs.json` for the current directory. Repeated saves of the same-named memory reuse the existing GUID, so the entry is updated in-place rather than duplicated.
+When a memory is saved, the REPL writes the entry to the global store and registers its GUID in `.fuseraft/memory/memory_refs.json` for the current directory. Repeated saves of the same-named memory reuse the existing GUID, so the entry is updated in-place rather than duplicated.
 
 At session start, scoped memories are injected into the system prompt. When the session ends (via `/exit` or Ctrl+C), the model is prompted to extract key facts and they are saved automatically.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,7 +99,7 @@ Orchestration:
 | 2 | Agent `Instructions` | Per-agent field in the config |
 | 3 | `.fuseraft/` folder orientation | Auto-injected from `FuseraftPaths.BuildFolderOrientationBlock()` — gives every agent a compact manifest of the runtime directory so they never call `list_files` on `.fuseraft/` to discover it. See [Directory layout](design.md#3-directory-layout). |
 | 4 | Context store summary | Appended when `.fuseraft/context/index.json` has entries (see [Context store](context-store.md)) |
-| 5 | Convention profile | Appended when `.fuseraft/conventions.json` exists (Brownfield mode) |
+| 5 | Convention profile | Appended when `.fuseraft/artifacts/conventions.json` exists (Brownfield mode) |
 | 6 | Test selector hint | Appended when `TestSelector.FindRelatedCommand` is configured |
 
 In **REPL mode** the same folder orientation is injected (blocks 3 onward), but the log-file entries are omitted from the manifest because the session section of the REPL system prompt already lists them and directs the agent to the `repl_session_*` tools for log access.
@@ -352,7 +352,7 @@ The `{AgentName}` component is sanitized so it is safe as a directory name. Agen
 
 The REPL always loads and saves memories automatically — no config flag is needed. Each REPL memory entry is identified by a UUID (stored in the file's frontmatter and used as its filename).
 
-Memories are **scoped to the working directory** where they were created. A file at `.fuseraft/memory_refs.json` in the current directory records the GUIDs of memories saved there. On session start the REPL loads only the entries listed in that file:
+Memories are **scoped to the working directory** where they were created. A file at `.fuseraft/memory/memory_refs.json` in the current directory records the GUIDs of memories saved there. On session start the REPL loads only the entries listed in that file:
 
 - Directories with a `.fuseraft/` folder but no refs file start with an empty memory set.
 - Directories without a `.fuseraft/` folder fall back to loading all global memories (useful outside a project context).
@@ -852,8 +852,8 @@ See [Skills](skills.md) for the full `SKILL.md` format reference and the skill i
 
 ```yaml
 Validation:
-  BriefPath: .fuseraft/brief.json
-  TestReportPath: .fuseraft/test-report.json
+  BriefPath: .fuseraft/artifacts/brief.json
+  TestReportPath: .fuseraft/artifacts/test-report.json
   TestAssertionPatterns:
     - tester::assert
     - "if .+ throw"
@@ -863,8 +863,8 @@ Validation:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `BriefPath` | string | `.fuseraft/brief.json` | Canonical path for the project brief. Required by `RequireBrief` and `TestReportValid`. |
-| `TestReportPath` | string | `.fuseraft/test-report.json` | Canonical path for the test report. Required by `TestReportValid`. |
+| `BriefPath` | string | `.fuseraft/artifacts/brief.json` | Canonical path for the project brief. Required by `RequireBrief` and `TestReportValid`. |
+| `TestReportPath` | string | `.fuseraft/artifacts/test-report.json` | Canonical path for the test report. Required by `TestReportValid`. |
 | `ChangeLogPath` | string | `.fuseraft/state/changes.json` | Path to `changes.json` produced by `ChangeTracking` (must match `ChangeTracking.Path`). Enables check 8 in `TestReportValid` and prior-turn file detection in `RequireAllFilesWritten`. |
 | `TestAssertionPatterns` | array | see above | Regex patterns that identify real assertion calls in test files. |
 
@@ -1051,7 +1051,7 @@ Contracts:
   - Name: ImplementationComplete
     Requires:
       - FilesWritten:
-          Source: .fuseraft/brief.json
+          Source: .fuseraft/artifacts/brief.json
           Field: files_to_change
       - CommandSucceeded:
           Pattern: "build|compile|go build|cargo build"
@@ -1059,7 +1059,7 @@ Contracts:
   - Name: TestsValid
     Requires:
       - FileExists:
-          Path: .fuseraft/test-report.json
+          Path: .fuseraft/artifacts/test-report.json
       - TestReport:
           NoFailures: true
           HasAssertions: true
@@ -1218,16 +1218,16 @@ Brownfield:
   EntryPoints:
     - src/cmd/server/main.go
     - src/internal/billing/charge.go
-  DiscoveryBriefPath: .fuseraft/brief.brownfield.json
-  ConventionProfilePath: .fuseraft/conventions.json
+  DiscoveryBriefPath: .fuseraft/artifacts/brief.brownfield.json
+  ConventionProfilePath: .fuseraft/artifacts/conventions.json
   SeedEnvelopeFromBrief: true
 ```
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `EntryPoints` | array | `[]` | Files or directories that seed the Archaeologist agent's dependency walk. Referenced in agent instructions; not automatically injected into prompts. Relative paths resolve against the sandbox root. |
-| `DiscoveryBriefPath` | string | `.fuseraft/brief.brownfield.json` | Path where the Archaeologist writes the discovery brief JSON. When `SeedEnvelopeFromBrief` is true and this file exists at startup, its `in_scope_files` list is merged into `Security.ChangeEnvelope`. |
-| `ConventionProfilePath` | string | `.fuseraft/conventions.json` | Path where the Archaeologist writes the convention profile JSON. When this file exists at session startup, its contents are formatted and prepended to every agent's system prompt. |
+| `DiscoveryBriefPath` | string | `.fuseraft/artifacts/brief.brownfield.json` | Path where the Archaeologist writes the discovery brief JSON. When `SeedEnvelopeFromBrief` is true and this file exists at startup, its `in_scope_files` list is merged into `Security.ChangeEnvelope`. |
+| `ConventionProfilePath` | string | `.fuseraft/artifacts/conventions.json` | Path where the Archaeologist writes the convention profile JSON. When this file exists at session startup, its contents are formatted and prepended to every agent's system prompt. |
 | `SeedEnvelopeFromBrief` | bool | `true` | When true and `DiscoveryBriefPath` exists, the `in_scope_files` list from the discovery brief is merged into `Security.ChangeEnvelope` at startup. Requires `Security.FileSystemSandboxPath` to be set for enforcement to take effect. |
 
 ### Brownfield discovery brief

--- a/docs/context-management.md
+++ b/docs/context-management.md
@@ -86,7 +86,7 @@ directory are loaded. Directories without `.fuseraft/` fall back to all global m
 
 **REPL:** Memory is always active in the REPL — no config flag needed. Memories are extracted
 automatically at the end of each session and scoped to the working directory via
-`.fuseraft/memory_refs.json`. Use `/memory` commands to inspect or delete them.
+`.fuseraft/memory/memory_refs.json`. Use `/memory` commands to inspect or delete them.
 
 **Memory cap:** The prompt block is capped at 8,000 characters. Entries are ordered by type
 then name; entries that would exceed the cap are dropped (header only is kept for visibility).
@@ -453,7 +453,7 @@ Here is the full sequence from session start through a long-running session:
 
 ```yaml
 ChangeTracking:
-  Path: .fuseraft/changes.json
+  Path: .fuseraft/state/changes.json
   IntentLogPath: .fuseraft/state/intents.json
 
 Compaction:

--- a/docs/design.md
+++ b/docs/design.md
@@ -110,12 +110,12 @@ All runtime artifacts are written under `.fuseraft/` in the current working dire
 | `.fuseraft/state/intents.json` | Intent log: pre-execution records updated to APPLIED/FAILED |
 | `.fuseraft/state/evidence.json` | Evidence graph: typed nodes for contract evaluation |
 | `.fuseraft/state/file_versions.json` | Per-file monotonic write counters for conflict detection |
-| `.fuseraft/brief.json` | Planner brief (validator input) |
-| `.fuseraft/test-report.json` | Tester report (validator input) |
-| `.fuseraft/chatroom.jsonl` | Shared agent coordination log |
-| `.fuseraft/conventions.json` | Brownfield convention profile (auto-injected into agent prompts) |
-| `.fuseraft/brief.brownfield.json` | Brownfield discovery brief (`in_scope_files` seeds change envelope) |
-| `.fuseraft/memory_refs.json` | GUIDs of memories scoped to this working directory |
+| `.fuseraft/artifacts/brief.json` | Planner brief (validator input) |
+| `.fuseraft/artifacts/test-report.json` | Tester report (validator input) |
+| `.fuseraft/comms/chatroom.jsonl` | Shared agent coordination log |
+| `.fuseraft/artifacts/conventions.json` | Brownfield convention profile (auto-injected into agent prompts) |
+| `.fuseraft/artifacts/brief.brownfield.json` | Brownfield discovery brief (`in_scope_files` seeds change envelope) |
+| `.fuseraft/memory/memory_refs.json` | GUIDs of memories scoped to this working directory |
 | `.fuseraft/context/` | Context store entries and index |
 | `.fuseraft/summaries/` | File summaries written by FileSystem plugin |
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -24,26 +24,26 @@ Orchestration:
     agents can only advance when evidence contracts are satisfied.
 
   EvidenceStore:
-    Path: .fuseraft/evidence.json
+    Path: .fuseraft/state/evidence.json
 
   ChangeTracking:
-    Path: .fuseraft/changes.json
+    Path: .fuseraft/state/changes.json
 
   Validation:
-    BriefPath: .fuseraft/brief.json
-    TestReportPath: .fuseraft/test-report.json
-    ChangeLogPath: .fuseraft/changes.json
+    BriefPath: .fuseraft/artifacts/brief.json
+    TestReportPath: .fuseraft/artifacts/test-report.json
+    ChangeLogPath: .fuseraft/state/changes.json
 
   Contracts:
     - Name: BriefExists
       Requires:
         - FileExists:
-            Path: .fuseraft/brief.json
+            Path: .fuseraft/artifacts/brief.json
 
     - Name: ImplementationComplete
       Requires:
         - FilesWritten:
-            Source: .fuseraft/brief.json
+            Source: .fuseraft/artifacts/brief.json
             Field: files_to_change
         - CommandSucceeded:
             Pattern: "build|compile"
@@ -51,7 +51,7 @@ Orchestration:
     - Name: TestsValid
       Requires:
         - FileExists:
-            Path: .fuseraft/test-report.json
+            Path: .fuseraft/artifacts/test-report.json
         - TestReport:
             NoFailures: true
             HasAssertions: true
@@ -82,7 +82,7 @@ Orchestration:
     - Name: Planner
       Description: Analyses the task and writes a structured brief.
       Instructions: |
-        You are a software planner. Analyse the task and write .fuseraft/brief.json:
+        You are a software planner. Analyse the task and write .fuseraft/artifacts/brief.json:
           { "goal": "...", "files_to_change": [{"path": "src/a.go", "reason": "..."}], "acceptance_criteria": [...], "implementation": [{"action": "write", "path": "src/a.go", "description": "..."}] }
         When done, call handoff(route_keyword: "HANDOFF TO DEVELOPER").
       Model:
@@ -95,7 +95,7 @@ Orchestration:
     - Name: Developer
       Description: Implements the changes described in the brief.
       Instructions: |
-        You are a software developer. Read .fuseraft/brief.json and implement every
+        You are a software developer. Read .fuseraft/artifacts/brief.json and implement every
         listed file using write_file. Run the build with shell_run to confirm it
         compiles. When done, call handoff(route_keyword: "HANDOFF TO TESTER").
         If you need a clearer plan, call handoff(route_keyword: "REPLAN REQUIRED").
@@ -113,8 +113,8 @@ Orchestration:
       Description: Writes and runs tests, produces a structured report.
       Instructions: |
         You are a software tester. Write tests covering the acceptance criteria in
-        .fuseraft/brief.json. Run them with shell_run. Write results to
-        .fuseraft/test-report.json:
+        .fuseraft/artifacts/brief.json. Run them with shell_run. Write results to
+        .fuseraft/artifacts/test-report.json:
           { "passed": true, "results": [{ "name": "TestFoo", "status": "PASS" }] }
         If tests fail, call handoff(route_keyword: "BUGS FOUND").
         When all pass, call handoff(route_keyword: "HANDOFF TO REVIEWER").
@@ -130,7 +130,7 @@ Orchestration:
     - Name: Reviewer
       Description: Reviews implementation and test results.
       Instructions: |
-        You are a code reviewer. Read the implementation and .fuseraft/test-report.json.
+        You are a code reviewer. Read the implementation and .fuseraft/artifacts/test-report.json.
         If the code meets all acceptance criteria, call handoff(route_keyword: "APPROVED").
         If changes are needed, call handoff(route_keyword: "REVISION REQUIRED") and
         explain exactly what to fix.
@@ -241,8 +241,8 @@ Orchestration:
   Brownfield:
     EntryPoints:
       - src/main.go
-    DiscoveryBriefPath: .fuseraft/brief.brownfield.json
-    ConventionProfilePath: .fuseraft/conventions.json
+    DiscoveryBriefPath: .fuseraft/artifacts/brief.brownfield.json
+    ConventionProfilePath: .fuseraft/artifacts/conventions.json
     SeedEnvelopeFromBrief: true
 
   TestSelector:
@@ -253,28 +253,28 @@ Orchestration:
     FileSystemSandboxPath: .
 
   EvidenceStore:
-    Path: .fuseraft/evidence.json
+    Path: .fuseraft/state/evidence.json
 
   ChangeTracking:
-    Path: .fuseraft/changes.json
+    Path: .fuseraft/state/changes.json
 
   Contracts:
     - Name: ReconComplete
       Requires:
         - FileExists:
-            Path: .fuseraft/brief.brownfield.json
+            Path: .fuseraft/artifacts/brief.brownfield.json
         - FileExists:
-            Path: .fuseraft/conventions.json
+            Path: .fuseraft/artifacts/conventions.json
 
     - Name: BriefExists
       Requires:
         - FileExists:
-            Path: .fuseraft/brief.json
+            Path: .fuseraft/artifacts/brief.json
 
     - Name: ImplementationComplete
       Requires:
         - FilesWritten:
-            Source: .fuseraft/brief.json
+            Source: .fuseraft/artifacts/brief.json
             Field: files_to_change
         - CommandSucceeded:
             Pattern: "build|compile|test"
@@ -282,7 +282,7 @@ Orchestration:
     - Name: TestsValid
       Requires:
         - FileExists:
-            Path: .fuseraft/test-report.json
+            Path: .fuseraft/artifacts/test-report.json
         - TestReport:
             NoFailures: true
             HasAssertions: true
@@ -418,7 +418,7 @@ Orchestration:
   Name: ResearchTeam
 
   EvidenceStore:
-    Path: .fuseraft/evidence.json
+    Path: .fuseraft/state/evidence.json
 
   Contracts:
     - Name: ResearchComplete
@@ -564,7 +564,7 @@ Orchestration:
       MaxTokens: 4096
 
   EvidenceStore:
-    Path: .fuseraft/evidence.json
+    Path: .fuseraft/state/evidence.json
 
   Contracts:
     - Name: PlanExists
@@ -822,10 +822,10 @@ Orchestration:
   Name: LongRunningTeam
 
   EvidenceStore:
-    Path: .fuseraft/evidence.json
+    Path: .fuseraft/state/evidence.json
 
   ChangeTracking:
-    Path: .fuseraft/changes.json
+    Path: .fuseraft/state/changes.json
 
   Compaction:
     TriggerTurnCount: 40

--- a/docs/harness-engineering.md
+++ b/docs/harness-engineering.md
@@ -25,7 +25,7 @@ Enable change tracking first — it is the ground-truth record that validators a
 
 ```yaml
 ChangeTracking:
-  Path: .fuseraft/changes.json
+  Path: .fuseraft/state/changes.json
 ```
 
 With this enabled, every `write_file`, `delete_file`, `shell_run`, `shell_run_script`, and `git_commit` call is recorded to `changes.json`. Downstream agents can call `changes_read_latest()` (via the `Changes` plugin) to see what previous agents actually did. Validators that reference `Validation.ChangeLogPath` cross-check their evidence against this log.
@@ -58,7 +58,7 @@ Blocks until `brief.json` exists on disk with non-empty `goal`, `files_to_change
     - Planner
 ```
 
-The Planner must call `write_file` to produce `.fuseraft/brief.json` before this route fires. A claimed brief — one described in prose but never written — will not pass.
+The Planner must call `write_file` to produce `.fuseraft/artifacts/brief.json` before this route fires. A claimed brief — one described in prose but never written — will not pass.
 
 ### RequireWriteFile
 
@@ -112,7 +112,7 @@ Without `RequiredCommandPattern`, any successful shell run satisfies the check. 
 
 ### TestReportValid
 
-Blocks unless a valid `.fuseraft/test-report.json` exists and passes eight structural checks, including: no FAIL results, real assertion patterns in test files, no empty `command` fields on PASS results, and (when a change log is configured) PASS result commands cross-referenced against commands that were actually executed.
+Blocks unless a valid `.fuseraft/artifacts/test-report.json` exists and passes eight structural checks, including: no FAIL results, real assertion patterns in test files, no empty `command` fields on PASS results, and (when a change log is configured) PASS result commands cross-referenced against commands that were actually executed.
 
 ```yaml
 - Keyword: "HANDOFF TO REVIEWER"
@@ -187,9 +187,9 @@ Provide file paths used by validators that read disk artifacts:
 
 ```yaml
 Validation:
-  BriefPath: .fuseraft/brief.json
-  TestReportPath: .fuseraft/test-report.json
-  ChangeLogPath: .fuseraft/changes.json
+  BriefPath: .fuseraft/artifacts/brief.json
+  TestReportPath: .fuseraft/artifacts/test-report.json
+  ChangeLogPath: .fuseraft/state/changes.json
   TestAssertionPatterns:
     - \bassert\b
     - \bexpect\b
@@ -236,7 +236,7 @@ To ground summaries in the change log, configure both `Compaction` and `ChangeTr
 
 ```yaml
 ChangeTracking:
-  Path: .fuseraft/changes.json
+  Path: .fuseraft/state/changes.json
 
 Compaction:
   TriggerTurnCount: 30
@@ -304,12 +304,12 @@ Orchestration:
   Name: Software Team
 
   ChangeTracking:
-    Path: .fuseraft/changes.json
+    Path: .fuseraft/state/changes.json
 
   Validation:
-    BriefPath: .fuseraft/brief.json
-    TestReportPath: .fuseraft/test-report.json
-    ChangeLogPath: .fuseraft/changes.json
+    BriefPath: .fuseraft/artifacts/brief.json
+    TestReportPath: .fuseraft/artifacts/test-report.json
+    ChangeLogPath: .fuseraft/state/changes.json
     TestAssertionPatterns:
       - \bassert\b
       - \bexpect\b
@@ -333,7 +333,7 @@ Orchestration:
     - Name: Planner
       Instructions: >-
         You are a software planner. Read the codebase, identify what needs to change,
-        and write .fuseraft/brief.json with goal, files_to_change, and acceptance_criteria.
+        and write .fuseraft/artifacts/brief.json with goal, files_to_change, and acceptance_criteria.
         When done, write HANDOFF TO DEVELOPER on its own line.
       Model: strong
       Plugins: [FileSystem]
@@ -342,7 +342,7 @@ Orchestration:
 
     - Name: Developer
       Instructions: >-
-        You are a software developer. Read .fuseraft/brief.json to understand the task.
+        You are a software developer. Read .fuseraft/artifacts/brief.json to understand the task.
         Implement every file in files_to_change. Run the build with shell_run to verify
         before handing off. Write HANDOFF TO TESTER on its own line when done.
       Model: strong
@@ -352,9 +352,9 @@ Orchestration:
 
     - Name: Tester
       Instructions: >-
-        You are a software tester. Read .fuseraft/brief.json for acceptance criteria.
+        You are a software tester. Read .fuseraft/artifacts/brief.json for acceptance criteria.
         Call changes_read_latest() to see what was implemented. Write tests, run them with shell_run,
-        and write .fuseraft/test-report.json before handing off.
+        and write .fuseraft/artifacts/test-report.json before handing off.
         Write HANDOFF TO REVIEWER on its own line when all tests pass.
         Write BUGS FOUND on its own line when tests fail.
       Model: strong
@@ -364,7 +364,7 @@ Orchestration:
 
     - Name: Reviewer
       Instructions: >-
-        You are a code reviewer. Read .fuseraft/brief.json and .fuseraft/test-report.json.
+        You are a code reviewer. Read .fuseraft/artifacts/brief.json and .fuseraft/artifacts/test-report.json.
         Verify the implementation against every acceptance criterion. Re-run key commands.
         Emit a JSON review block before your decision keyword.
         Write APPROVED on its own line when satisfied.

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -304,7 +304,7 @@ Orchestration:
     - Name: ImplementationComplete
       Requires:
         - FilesWritten:
-            Source: .fuseraft/brief.json
+            Source: .fuseraft/artifacts/brief.json
             Field: files_to_change
         - CommandSucceeded:
             Pattern: "build|compile"

--- a/docs/validators.md
+++ b/docs/validators.md
@@ -87,9 +87,9 @@ The `Validation` section provides file paths and patterns used by the validators
 
 ```yaml
 Validation:
-  BriefPath: .fuseraft/brief.json
-  TestReportPath: .fuseraft/test-report.json
-  ChangeLogPath: .fuseraft/changes.json
+  BriefPath: .fuseraft/artifacts/brief.json
+  TestReportPath: .fuseraft/artifacts/test-report.json
+  ChangeLogPath: .fuseraft/state/changes.json
   TestAssertionPatterns:
     - tester::assert
     - "if .+ throw"
@@ -105,7 +105,7 @@ The `Validation` section is required when any route uses `TestReportValid`. It i
 
 **Used on:** `HANDOFF TO DEVELOPER` (blocks the Planner from handing off without a written brief)
 
-**What it checks:** Reads `brief.json` from `Validation.BriefPath` (default `.fuseraft/brief.json`) and verifies it exists on disk with valid, complete content.
+**What it checks:** Reads `brief.json` from `Validation.BriefPath` (default `.fuseraft/artifacts/brief.json`) and verifies it exists on disk with valid, complete content.
 
 **Passes if:** `brief.json` exists, is valid JSON, and contains non-empty `goal`, `files_to_change`, `acceptance_criteria`, and `implementation` fields.
 
@@ -347,7 +347,7 @@ Command: pytest tests/test_api.py tests/test_auth.py
 
 ### Test report schema
 
-The Tester must write a file at `Validation.TestReportPath` (default `.fuseraft/test-report.json`) matching this schema before writing `HANDOFF TO REVIEWER`:
+The Tester must write a file at `Validation.TestReportPath` (default `.fuseraft/artifacts/test-report.json`) matching this schema before writing `HANDOFF TO REVIEWER`:
 
 ```json
 {
@@ -512,7 +512,7 @@ to confirm behavioral correctness:
 
 ```yaml
 Validation:
-  BriefPath: .fuseraft/brief.json
+  BriefPath: .fuseraft/artifacts/brief.json
 
 Selection:
   Type: keyword
@@ -587,8 +587,8 @@ Run the indicated command(s), confirm the expected output appears, then retry th
 
 ```yaml
 Validation:
-  BriefPath:     .fuseraft/brief.json
-  ChangeLogPath: .fuseraft/changes.json
+  BriefPath:     .fuseraft/artifacts/brief.json
+  ChangeLogPath: .fuseraft/state/changes.json
 
 Selection:
   Type: keyword
@@ -659,7 +659,7 @@ Orchestration:
     - Name: ImplementationComplete
       Requires:
         - FilesWritten:
-            Source: .fuseraft/brief.json
+            Source: .fuseraft/artifacts/brief.json
             Field: files_to_change
         - CommandSucceeded:
             Pattern: "build|compile|go build|cargo build"
@@ -667,7 +667,7 @@ Orchestration:
     - Name: TestsValid
       Requires:
         - FileExists:
-            Path: .fuseraft/test-report.json
+            Path: .fuseraft/artifacts/test-report.json
         - TestReport:
             NoFailures: true
             HasAssertions: true

--- a/src/Cli/Commands/InitTemplates.Content.cs
+++ b/src/Cli/Commands/InitTemplates.Content.cs
@@ -17,7 +17,7 @@ public static partial class InitTemplates
             Instructions: |
               You are a creative and precise writer. Your job is to:
               1. Understand the content brief from the task.
-              2. Write a complete draft and save it to output/draft.md using write_file.
+              2. Write a complete draft and save it to {FuseraftPaths.LocalDocs}/draft.md using write_file.
               When the draft is ready for review, call handoff(route_keyword: "DRAFT_COMPLETE").
             Model:
               ModelId: {model}{EpAgent(endpoint)}
@@ -34,9 +34,9 @@ public static partial class InitTemplates
             Description: Edits for clarity, accuracy, and style; writes the final version.
             Instructions: |
               You are a senior editor. Your job is to:
-              1. Read the draft from output/draft.md.
+              1. Read the draft from {FuseraftPaths.LocalDocs}/draft.md.
               2. Edit for clarity, accuracy, tone, and structure.
-              3. Save the final version to output/final.md using write_file.
+              3. Save the final version to {FuseraftPaths.LocalDocs}/final.md using write_file.
               When editing is complete, call handoff(route_keyword: "CONTENT_APPROVED").
             Model:
               ModelId: {model}{EpAgent(endpoint)}
@@ -60,7 +60,7 @@ public static partial class InitTemplates
                 - Name: DraftExists
                   Requires:
                     - Type: FileExists
-                      Path: output/draft.md
+                      Path: {FuseraftPaths.LocalDocs}/draft.md
 
               # Each agent lives in its own YAML file in agents/ — edit, version, or reuse
               # them independently across configs. Inline fields override the file at load time.

--- a/src/Cli/Commands/InitTemplates.DevTeam.cs
+++ b/src/Cli/Commands/InitTemplates.DevTeam.cs
@@ -65,7 +65,8 @@ public static partial class InitTemplates
             Instructions: |
               You are a QA engineer. Your job is to:
               1. Read {FuseraftPaths.LocalBrief} to understand acceptance criteria.
-              2. Write tests and run them with shell_run.
+              2. Write test scripts (any format) to {FuseraftPaths.LocalTests}/ and any
+                 fixture or seed files to {FuseraftPaths.LocalTestFixtures}/. Run them with shell_run.
               3. Write results to {FuseraftPaths.LocalTestReport}:
                    passed — true if every criterion passes, false otherwise
                    results — array of objects:

--- a/src/Cli/Commands/InitTemplates.Graph.cs
+++ b/src/Cli/Commands/InitTemplates.Graph.cs
@@ -65,7 +65,8 @@ public static partial class InitTemplates
             Instructions: |
               You are a QA engineer. Your job is to:
               1. Read {FuseraftPaths.LocalBrief} to understand the acceptance criteria.
-              2. Write tests and run them with shell_run.
+              2. Write test scripts (any format) to {FuseraftPaths.LocalTests}/ and any
+                 fixture or seed files to {FuseraftPaths.LocalTestFixtures}/. Run them with shell_run.
               3. Write results to {FuseraftPaths.LocalTestReport}:
                    passed — true if every criterion passes, false otherwise
                    results — array of objects:

--- a/src/Cli/Commands/InitTemplates.Research.cs
+++ b/src/Cli/Commands/InitTemplates.Research.cs
@@ -18,7 +18,7 @@ public static partial class InitTemplates
               You are a diligent researcher. Your job is to:
               1. Break the topic into focused questions.
               2. Search for answers using available tools.
-              3. Write your structured findings to .fuseraft/research-findings.md.
+              3. Write your structured findings to {FuseraftPaths.LocalDocs}/research-findings.md.
               When your research is thorough and complete, call handoff(route_keyword: "HANDOFF TO WRITER").
             Model:
               ModelId: {model}{EpAgent(endpoint)}
@@ -36,9 +36,9 @@ public static partial class InitTemplates
             Description: Turns research findings into a polished final document.
             Instructions: |
               You are a skilled technical writer. Your job is to:
-              1. Read the research findings from .fuseraft/research-findings.md.
+              1. Read the research findings from {FuseraftPaths.LocalDocs}/research-findings.md.
               2. Synthesize a clear, well-structured document that answers the original question.
-              3. Write the final document to .fuseraft/report.md.
+              3. Write the final document to {FuseraftPaths.LocalDocs}/report.md.
               When done, call handoff(route_keyword: "DOCUMENT COMPLETE").
             Model:
               ModelId: {model}{EpAgent(endpoint)}
@@ -62,7 +62,7 @@ public static partial class InitTemplates
                 - Name: ResearchComplete
                   Requires:
                     - Type: FileExists
-                      Path: .fuseraft/research-findings.md
+                      Path: {FuseraftPaths.LocalDocs}/research-findings.md
 
               # Each agent lives in its own YAML file in agents/ — edit, version, or reuse
               # them independently across configs. Inline fields override the file at load time.

--- a/src/Core/FuseraftPaths.cs
+++ b/src/Core/FuseraftPaths.cs
@@ -55,13 +55,27 @@ public static class FuseraftPaths
     public const string LocalEvidence     = ".fuseraft/state/evidence.json";
     public const string LocalFileVersions = ".fuseraft/state/file_versions.json";
 
-    // Agent artifacts and validator inputs (user-visible at root)
-    public const string LocalBrief           = ".fuseraft/brief.json";
-    public const string LocalTestReport      = ".fuseraft/test-report.json";
-    public const string LocalChatroom        = ".fuseraft/chatroom.jsonl";
-    public const string LocalConventions     = ".fuseraft/conventions.json";
-    public const string LocalBrownfieldBrief = ".fuseraft/brief.brownfield.json";
-    public const string LocalMemoryRefs      = ".fuseraft/memory_refs.json";
+    // artifacts/ — structured agent-written documents read by validators
+    public const string LocalArtifacts       = ".fuseraft/artifacts";
+    public const string LocalBrief           = ".fuseraft/artifacts/brief.json";
+    public const string LocalTestReport      = ".fuseraft/artifacts/test-report.json";
+    public const string LocalConventions     = ".fuseraft/artifacts/conventions.json";
+    public const string LocalBrownfieldBrief = ".fuseraft/artifacts/brief.brownfield.json";
+
+    // comms/ — cross-agent communication channels
+    public const string LocalComms    = ".fuseraft/comms";
+    public const string LocalChatroom = ".fuseraft/comms/chatroom.jsonl";
+
+    // memory/ (local) — session-scoped memory reference index
+    public const string LocalMemory     = ".fuseraft/memory";
+    public const string LocalMemoryRefs = ".fuseraft/memory/memory_refs.json";
+
+    // docs/ — agent-written markdown documents (research, reports, drafts, notes)
+    public const string LocalDocs = ".fuseraft/docs";
+
+    // tests/ — tester-created test scripts and fixture files (any language/format)
+    public const string LocalTests        = ".fuseraft/tests";
+    public const string LocalTestFixtures = ".fuseraft/tests/fixtures";
 
     // Already-subdirectorized paths (unchanged locations)
     public const string LocalContext   = ".fuseraft/context";
@@ -85,18 +99,24 @@ public static class FuseraftPaths
         sb.AppendLine("This directory is managed by fuseraft-cli. Never call list_files or explore .fuseraft/ — reference these paths directly when needed:");
         if (includeLogs)
         {
-            sb.AppendLine("  .fuseraft/logs/events.jsonl        — agent/orchestration event log (JSONL)");
-            sb.AppendLine("  .fuseraft/logs/repl_events.jsonl   — REPL event log (JSONL)");
-            sb.AppendLine("  .fuseraft/logs/app.log             — application log");
+            sb.AppendLine("  .fuseraft/logs/events.jsonl               — agent/orchestration event log (JSONL)");
+            sb.AppendLine("  .fuseraft/logs/repl_events.jsonl          — REPL event log (JSONL)");
+            sb.AppendLine("  .fuseraft/logs/app.log                    — application log");
         }
-        sb.AppendLine("  .fuseraft/state/changes.json       — tool-call change log");
-        sb.AppendLine("  .fuseraft/state/intents.json       — in-progress intent records (consult before repeating work)");
-        sb.AppendLine("  .fuseraft/state/evidence.json      — structured evidence graph");
-        sb.AppendLine("  .fuseraft/state/file_versions.json — per-file versioned write counters");
-        sb.AppendLine("  .fuseraft/brief.json               — task brief (if present)");
-        sb.AppendLine("  .fuseraft/chatroom.jsonl           — cross-agent chatroom messages (if present)");
-        sb.AppendLine("  .fuseraft/context/                 — injected reference documents (see .fuseraft/context/index.json)");
-        sb.Append(    "  .fuseraft/summaries/               — compaction summaries");
+        sb.AppendLine("  .fuseraft/state/changes.json              — tool-call change log");
+        sb.AppendLine("  .fuseraft/state/intents.json              — in-progress intent records (consult before repeating work)");
+        sb.AppendLine("  .fuseraft/state/evidence.json             — structured evidence graph");
+        sb.AppendLine("  .fuseraft/state/file_versions.json        — per-file versioned write counters");
+        sb.AppendLine("  .fuseraft/artifacts/brief.json            — task brief (if present)");
+        sb.AppendLine("  .fuseraft/artifacts/brief.brownfield.json — brownfield discovery brief (if present)");
+        sb.AppendLine("  .fuseraft/artifacts/test-report.json      — tester output / validator input (if present)");
+        sb.AppendLine("  .fuseraft/artifacts/conventions.json      — brownfield convention profile (if present)");
+        sb.AppendLine("  .fuseraft/comms/chatroom.jsonl            — cross-agent chatroom messages (if present)");
+        sb.AppendLine("  .fuseraft/docs/                           — write all markdown notes, reports, and drafts here");
+        sb.AppendLine("  .fuseraft/tests/                          — write all test scripts and test support files here");
+        sb.AppendLine("  .fuseraft/tests/fixtures/                 — seed data, stubs, and fixture files");
+        sb.AppendLine("  .fuseraft/context/                        — injected reference documents (see .fuseraft/context/index.json)");
+        sb.Append(    "  .fuseraft/summaries/                      — compaction summaries");
         return sb.ToString();
     }
 }

--- a/src/Infrastructure/AgentFactory.cs
+++ b/src/Infrastructure/AgentFactory.cs
@@ -7,6 +7,7 @@ using AgentGovernance.Trust;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
+using fuseraft.Core;
 using fuseraft.Core.Models;
 using fuseraft.Infrastructure.Plugins;
 using fuseraft.Orchestration;
@@ -283,7 +284,7 @@ public sealed class AgentFactory(
             // "Chatroom" is per-agent (own sender name) but all agents share the same file.
             else if (pluginName.Equals("Chatroom", StringComparison.OrdinalIgnoreCase))
             {
-                var chatPath = chatroomConfig?.Path ?? ".fuseraft/chatroom.jsonl";
+                var chatPath = chatroomConfig?.Path ?? FuseraftPaths.LocalChatroom;
                 functions = PluginRegistry.GetFunctionsFromObject(new ChatroomPlugin(config.Name, chatPath));
             }
             else if (pluginRegistry.TryGetAIFunctions(pluginName, out var aiFunctions))

--- a/src/Infrastructure/Plugins/PluginRegistry.cs
+++ b/src/Infrastructure/Plugins/PluginRegistry.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
+using fuseraft.Core;
 using fuseraft.Core.Models;
 
 namespace fuseraft.Infrastructure.Plugins;
@@ -81,8 +82,8 @@ public sealed class PluginRegistry : IDisposable
             Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
             ".fuseraft", "scratchpad");
         Register("Scratchpad", () => new ScratchpadPlugin("agent", scratchpadBase));
-        Register("Chatroom",   () => new ChatroomPlugin("agent", ".fuseraft/chatroom.jsonl"));
-        Register("Changes",    () => new ChangesPlugin(".fuseraft/changes.json"));
+        Register("Chatroom",   () => new ChatroomPlugin("agent", FuseraftPaths.LocalChatroom));
+        Register("Changes",    () => new ChangesPlugin(FuseraftPaths.LocalChanges));
 
         // SubAgent stub — AgentFactory replaces this with a real instance that has a
         // live IChatClient and sandboxed FileSystem + Search tools for the sub-agent loop.

--- a/src/Orchestration/Contracts/ContractEngine.cs
+++ b/src/Orchestration/Contracts/ContractEngine.cs
@@ -1,6 +1,7 @@
 using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using fuseraft.Core;
 using fuseraft.Core.Models;
 using fuseraft.Infrastructure.Plugins;
 using fuseraft.Orchestration.Validation;
@@ -191,7 +192,7 @@ public sealed class ContractEngine
         {
             var sourcePath = pred.PatternSource
                 ?? _validationConfig?.BriefPath
-                ?? ".fuseraft/brief.json";
+                ?? FuseraftPaths.LocalBrief;
 
             if (!File.Exists(sourcePath))
                 return (false,
@@ -240,7 +241,7 @@ public sealed class ContractEngine
             return (true, null);
 
         var resolvedFrom = pred.PatternField is not null
-            ? $" (read from '{pred.PatternSource ?? ".fuseraft/brief.json"}' field '{pred.PatternField}')"
+            ? $" (read from '{pred.PatternSource ?? FuseraftPaths.LocalBrief}' field '{pred.PatternField}')"
             : string.Empty;
 
         return (false,
@@ -270,7 +271,7 @@ public sealed class ContractEngine
         string contractName,
         CancellationToken ct)
     {
-        var reportPath = _validationConfig?.TestReportPath ?? ".fuseraft/test-report.json";
+        var reportPath = _validationConfig?.TestReportPath ?? FuseraftPaths.LocalTestReport;
 
         if (!File.Exists(reportPath))
         {
@@ -345,7 +346,7 @@ public sealed class ContractEngine
     // Reads acceptance_criteria from brief.json (best-effort; returns empty on any error).
     private async Task<List<string>> TryReadAcceptanceCriteriaAsync(CancellationToken ct)
     {
-        var briefPath = _validationConfig?.BriefPath ?? ".fuseraft/brief.json";
+        var briefPath = _validationConfig?.BriefPath ?? FuseraftPaths.LocalBrief;
         if (!File.Exists(briefPath)) return [];
 
         try

--- a/src/Orchestration/ConversationCompactor.cs
+++ b/src/Orchestration/ConversationCompactor.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
+using fuseraft.Core;
 using fuseraft.Core.Interfaces;
 using fuseraft.Core.Models;
 
@@ -476,7 +477,7 @@ public sealed class ConversationCompactor(
     /// </summary>
     public const string WorkflowResumptionNote =
         "RESUMPTION NOTE: History compacted. Before acting: " +
-        "(1) read_file .fuseraft/brief.json, " +
+        $"(1) read_file {FuseraftPaths.LocalBrief}, " +
         "(2) changes_read_latest to confirm what is already done, " +
         "(3) do not redo work changes.json confirms is complete.";
 

--- a/src/Orchestration/Strategies/KeywordSelectionStrategy.cs
+++ b/src/Orchestration/Strategies/KeywordSelectionStrategy.cs
@@ -4,6 +4,7 @@ using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using fuseraft.Core.Exceptions;
+using fuseraft.Core;
 using fuseraft.Core.Interfaces;
 using fuseraft.Core.Models;
 using fuseraft.Infrastructure.Plugins;
@@ -792,7 +793,7 @@ public sealed class KeywordSelectionStrategy : IAgentSelector
 
             FailureType.MissingEvidence =>
                 $"{prefix}MISSING ARTIFACT: Required file not on disk.\n" +
-                $"  1. read_file .fuseraft/brief.json\n" +
+                $"  1. read_file {FuseraftPaths.LocalBrief}\n" +
                 $"  2. write_file or create the missing artifact.\n" +
                 $"  3. Verify with read_file, then retry the handoff.\n\n" +
                 errorMessage,
@@ -846,7 +847,7 @@ public sealed class KeywordSelectionStrategy : IAgentSelector
         {
             _history.Add(new ChatMessage(ChatRole.User,
                 $"LOOP WARNING: {agent.Name} — {consecutive} consecutive turns, task incomplete.\n" +
-                $"  1. read_file .fuseraft/brief.json\n" +
+                $"  1. read_file {FuseraftPaths.LocalBrief}\n" +
                 $"  2. changes_read_latest\n" +
                 $"  3. Execute the single blocking action.\n" +
                 $"  4. Emit the handoff keyword."));

--- a/src/Orchestration/Strategies/StateMachineSelectionStrategy.cs
+++ b/src/Orchestration/Strategies/StateMachineSelectionStrategy.cs
@@ -3,6 +3,7 @@ using AgentGovernance.Audit;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
+using fuseraft.Core;
 using fuseraft.Core.Exceptions;
 using fuseraft.Core.Interfaces;
 using fuseraft.Core.Models;
@@ -477,7 +478,7 @@ public sealed class StateMachineSelectionStrategy : IAgentSelector, IContextSnap
                 $"{prefix}MISSING ARTIFACT — Transition '{fromState}' → '{toState}' is blocked " +
                 $"because contract '{contractName}' requires an artifact that does not exist yet.\n\n" +
                 $"Steps to resolve:\n" +
-                $"  1. Read .fuseraft/brief.json to identify the required artifacts.\n" +
+                $"  1. Read {FuseraftPaths.LocalBrief} to identify the required artifacts.\n" +
                 $"  2. Create the missing artifact using write_file or the appropriate tool.\n" +
                 $"  3. Re-emit the signal once the artifact exists.\n\n" +
                 errorMessage,
@@ -564,7 +565,7 @@ public sealed class StateMachineSelectionStrategy : IAgentSelector, IContextSnap
                 $"LOOP WARNING: {agentName} has been invoked {consecutive} consecutive turns " +
                 $"in state '{_currentState}' without completing the required task. " +
                 $"You appear to be stuck. Take these steps:\n" +
-                $"  1. Call read_file on .fuseraft/brief.json to restore the task brief.\n" +
+                $"  1. Call read_file on {FuseraftPaths.LocalBrief} to restore the task brief.\n" +
                 $"  2. Call changes_read_latest to see what has already been done.\n" +
                 $"  3. Identify the single blocking action and execute it now.\n" +
                 $"  4. Emit the correct transition signal once that action is complete."));


### PR DESCRIPTION
## Summary

The purpose of this PR is to better organize the files the agents produce to the .fuseraft directory. Currently, the agents are able to put .md documentation and testing files into the main directory which can clutter up the project. This change aims to organize the files the agents produce that aren't dependencies for the core project to keep the project structure clean.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Plugin
- [ ] Config example
- [ ] Documentation
- [ x] Refactor / cleanup
- [ ] Other: <!-- describe -->

## Related issues

No related issue

## Changes

Changed where the agents can put the files they create that are specific for their tasks.

-

## Testing

<!-- How did you verify this? Check all that apply. -->

- [ ] Added or updated unit tests
- [ ] All tests pass locally (`./build.sh --target=Test`)
- [ ] Tested manually end-to-end
- [ ] Documentation updated where relevant
- [ ] `config/examples/` updated if config schema changed
- [ x] didn't test :^)

## Invariants

<!-- For changes to orchestration, strategies, or validators — confirm these hold. -->

- [ x] Execution order unchanged (Selection → Validation → Failure handling → Termination → Iteration cap)
- [x] Any new file/shell/git tool is wrapped by `ChangeTracker`
- [ x] Any new validator is deterministic, side-effect free, and idempotent
- [ x] Physical history is not stripped or reordered outside of compaction

<!-- Not applicable to most PRs — uncheck or remove the section if so. -->

## Notes for reviewers

<!-- Anything that would help a reviewer understand context, trade-offs, or what to focus on. -->
