### PR TITLE
feat: add range validation for fractional fields (TrustScore, ContextCapFraction, AntiThrashMinSavingsRatio)

### DIFF
--- a/src/Cli/Commands/ValidateConfigCommand.cs
+++ b/src/Cli/Commands/ValidateConfigCommand.cs
@@ -270,6 +270,12 @@ public sealed class ValidateConfigCommand(PluginRegistry pluginRegistry) : Async
                 if (agent.FunctionChoice.ToLowerInvariant() is not ("auto" or "required" or "none"))
                     issues.Add(("error", $"Agent '{agent.Name}': FunctionChoice '{agent.FunctionChoice}' is invalid. Valid values: auto, required, none."));
 
+                if (agent.TrustScore is < 0.0 or > 1.0)
+                    issues.Add(("error", $"Agent '{agent.Name}': TrustScore must be 0.0–1.0 (got {agent.TrustScore})."));
+
+                if (agent.ContextWindow?.ContextCapFraction is < 0.0 or > 1.0)
+                    issues.Add(("error", $"Agent '{agent.Name}': ContextCapFraction must be 0.0–1.0 (got {agent.ContextWindow.ContextCapFraction})."));
+
                 var effort = agent.Model.ReasoningEffort?.ToLowerInvariant();
                 if (effort is not null and not ("none" or "low" or "medium" or "high"))
                     issues.Add(("error", $"Agent '{agent.Name}': Model.ReasoningEffort '{agent.Model.ReasoningEffort}' is invalid. Valid values: none, low, medium, high."));
@@ -310,6 +316,9 @@ public sealed class ValidateConfigCommand(PluginRegistry pluginRegistry) : Async
                     "The per-turn warning fires in the same turn as compaction — lower WarnTurnTokens " +
                     "below CutoverAt to get an advance signal."));
         }
+
+        if (config.Compaction?.AntiThrashMinSavingsRatio is < 0.0 or > 1.0)
+            issues.Add(("error", $"Compaction.AntiThrashMinSavingsRatio must be 0.0–1.0 (got {config.Compaction.AntiThrashMinSavingsRatio})."));
     }
 
     private static void ValidateMemoryLayer(

--- a/tests/FuseraftCli.Tests/ValidateConfigCommandTests.cs
+++ b/tests/FuseraftCli.Tests/ValidateConfigCommandTests.cs
@@ -1298,6 +1298,188 @@ public class ValidateConfigCommandTests : IDisposable
     }
 
     // -----------------------------------------------------------------------
+    // Fractional range validation tests
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task TrustScore_OutOfRange_Errors()
+    {
+        var config = """
+        {
+          "Orchestration": {
+            "Agents": [
+              {"Name": "A", "Instructions": "ok", "Model": {"ModelId": "gpt-4o"}, "TrustScore": 1.5}
+            ],
+            "Selection": {"Type": "sequential"},
+            "Termination": {"Type": "maxiterations", "MaxIterations": 10}
+          }
+        }
+        """;
+        var tempPath = CreateTempFile(config);
+        var settings = new ValidateConfigSettings { Path = tempPath };
+
+        var registry = new PluginRegistry();
+        registry.RegisterDefaults();
+        var command = new ValidateConfigCommand(registry);
+        var exitCode = await command.ExecuteAsync(null!, settings);
+
+        Assert.Equal(1, exitCode);
+    }
+
+    [Fact]
+    public async Task TrustScore_OutOfRange_Negative_Errors()
+    {
+        var config = """
+        {
+          "Orchestration": {
+            "Agents": [
+              {"Name": "A", "Instructions": "ok", "Model": {"ModelId": "gpt-4o"}, "TrustScore": -0.1}
+            ],
+            "Selection": {"Type": "sequential"},
+            "Termination": {"Type": "maxiterations", "MaxIterations": 10}
+          }
+        }
+        """;
+        var tempPath = CreateTempFile(config);
+        var settings = new ValidateConfigSettings { Path = tempPath };
+
+        var registry = new PluginRegistry();
+        registry.RegisterDefaults();
+        var command = new ValidateConfigCommand(registry);
+        var exitCode = await command.ExecuteAsync(null!, settings);
+
+        Assert.Equal(1, exitCode);
+    }
+
+    [Fact]
+    public async Task TrustScore_BoundaryValues_Valid()
+    {
+        var config = """
+        {
+          "Orchestration": {
+            "Agents": [
+              {"Name": "A", "Instructions": "ok", "Model": {"ModelId": "gpt-4o"}, "TrustScore": 0.0},
+              {"Name": "B", "Instructions": "ok", "Model": {"ModelId": "gpt-4o"}, "TrustScore": 1.0}
+            ],
+            "Selection": {"Type": "sequential"},
+            "Termination": {"Type": "maxiterations", "MaxIterations": 10}
+          }
+        }
+        """;
+        var tempPath = CreateTempFile(config);
+        var settings = new ValidateConfigSettings { Path = tempPath };
+
+        var registry = new PluginRegistry();
+        registry.RegisterDefaults();
+        var command = new ValidateConfigCommand(registry);
+        var exitCode = await command.ExecuteAsync(null!, settings);
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task ContextCapFraction_OutOfRange_Errors()
+    {
+        var config = """
+        {
+          "Orchestration": {
+            "Agents": [
+              {"Name": "A", "Instructions": "ok", "Model": {"ModelId": "gpt-4o"}, "ContextWindow": {"ContextCapFraction": 1.5}}
+            ],
+            "Selection": {"Type": "sequential"},
+            "Termination": {"Type": "maxiterations", "MaxIterations": 10}
+          }
+        }
+        """;
+        var tempPath = CreateTempFile(config);
+        var settings = new ValidateConfigSettings { Path = tempPath };
+
+        var registry = new PluginRegistry();
+        registry.RegisterDefaults();
+        var command = new ValidateConfigCommand(registry);
+        var exitCode = await command.ExecuteAsync(null!, settings);
+
+        Assert.Equal(1, exitCode);
+    }
+
+    [Fact]
+    public async Task ContextCapFraction_Negative_Errors()
+    {
+        var config = """
+        {
+          "Orchestration": {
+            "Agents": [
+              {"Name": "A", "Instructions": "ok", "Model": {"ModelId": "gpt-4o"}, "ContextWindow": {"ContextCapFraction": -0.2}}
+            ],
+            "Selection": {"Type": "sequential"},
+            "Termination": {"Type": "maxiterations", "MaxIterations": 10}
+          }
+        }
+        """;
+        var tempPath = CreateTempFile(config);
+        var settings = new ValidateConfigSettings { Path = tempPath };
+
+        var registry = new PluginRegistry();
+        registry.RegisterDefaults();
+        var command = new ValidateConfigCommand(registry);
+        var exitCode = await command.ExecuteAsync(null!, settings);
+
+        Assert.Equal(1, exitCode);
+    }
+
+    [Fact]
+    public async Task AntiThrashMinSavingsRatio_OutOfRange_Errors()
+    {
+        var config = """
+        {
+          "Orchestration": {
+            "Agents": [
+              {"Name": "A", "Instructions": "ok", "Model": {"ModelId": "gpt-4o"}}
+            ],
+            "Selection": {"Type": "sequential"},
+            "Termination": {"Type": "maxiterations", "MaxIterations": 10},
+            "Compaction": {"AntiThrashMinSavingsRatio": 1.1}
+          }
+        }
+        """;
+        var tempPath = CreateTempFile(config);
+        var settings = new ValidateConfigSettings { Path = tempPath };
+
+        var registry = new PluginRegistry();
+        registry.RegisterDefaults();
+        var command = new ValidateConfigCommand(registry);
+        var exitCode = await command.ExecuteAsync(null!, settings);
+
+        Assert.Equal(1, exitCode);
+    }
+
+    [Fact]
+    public async Task AntiThrashMinSavingsRatio_Negative_Errors()
+    {
+        var config = """
+        {
+          "Orchestration": {
+            "Agents": [
+              {"Name": "A", "Instructions": "ok", "Model": {"ModelId": "gpt-4o"}}
+            ],
+            "Selection": {"Type": "sequential"},
+            "Termination": {"Type": "maxiterations", "MaxIterations": 10},
+            "Compaction": {"AntiThrashMinSavingsRatio": -0.05}
+          }
+        }
+        """;
+        var tempPath = CreateTempFile(config);
+        var settings = new ValidateConfigSettings { Path = tempPath };
+
+        var registry = new PluginRegistry();
+        registry.RegisterDefaults();
+        var command = new ValidateConfigCommand(registry);
+        var exitCode = await command.ExecuteAsync(null!, settings);
+
+        Assert.Equal(1, exitCode);
+    }
+
+    // -----------------------------------------------------------------------
     // Helpers
     // -----------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #28

## Summary
Adds [0, 1] range validation for three fractional config properties in the validate command.

### Part A — Fractional range checks

**ValidateAgents:**
- TrustScore must be 0.0–1.0
- ContextCapFraction must be 0.0–1.0

**ValidateCompactionConfig:**
- AntiThrashMinSavingsRatio must be 0.0–1.0

Note: Part B (WarnAt >= CutoverAt) was already resolved.

### Tests (7 new)
All 59 tests pass.